### PR TITLE
Allow disabling component selector resolving in books and update patch notes

### DIFF
--- a/patches/server/0056-Faster-redstone-torch-rapid-clock-removal.patch
+++ b/patches/server/0056-Faster-redstone-torch-rapid-clock-removal.patch
@@ -1,9 +1,9 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: uRyanxD <familiarodrigues123ro@gmail.com>
-Date: Sat, 28 May 2022 17:18:57 -0300
+From: Martin Panzer <postremus1996@googlemail.com>
+Date: Mon, 23 May 2016 12:12:37 +0200
 Subject: [PATCH] Faster redstone torch rapid clock removal
 
-Backported from Paper#0137.
+Only resize the the redstone torch list once, since resizing arrays / lists is costly
 
 diff --git a/src/main/java/net/minecraft/server/BlockRedstoneTorch.java b/src/main/java/net/minecraft/server/BlockRedstoneTorch.java
 index 78c6d195a4fe0960b1c5e38d711fe7c723c3a5d3..99d7320be7fd5eb2814c1ca5758f61de56174e65 100644

--- a/patches/server/0061-Allow-disabling-component-selector-resolving-in-book.patch
+++ b/patches/server/0061-Allow-disabling-component-selector-resolving-in-book.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: uRyanxD <familiarodrigues123ro@gmail.com>
+Date: Fri, 3 Jun 2022 20:36:24 -0300
+Subject: [PATCH] Allow disabling component selector resolving in books
+
+
+diff --git a/src/main/java/com/hpfxd/pandaspigot/config/PandaSpigotConfig.java b/src/main/java/com/hpfxd/pandaspigot/config/PandaSpigotConfig.java
+index fcf7738c75f21ad23693d903b476c65b4a207a84..d9601dbc194a622ceb3f7a7c740729cb8b890e8f 100644
+--- a/src/main/java/com/hpfxd/pandaspigot/config/PandaSpigotConfig.java
++++ b/src/main/java/com/hpfxd/pandaspigot/config/PandaSpigotConfig.java
+@@ -119,4 +119,6 @@ public class PandaSpigotConfig {
+         "https://docs.papermc.io/paper/reference/paper-global-configuration#packet-limiter\n" +
+         "(note that \"max-packet-rate\" is renamed to \"maxPacketRate\")")
+     public PacketLimiterConfig packetLimiter = PacketLimiterConfig.createDefault();
++
++    public boolean resolveSelectorsInBooks = true;
+ }
+diff --git a/src/main/java/net/minecraft/server/ItemWrittenBook.java b/src/main/java/net/minecraft/server/ItemWrittenBook.java
+index d179049724abe8d5e7a914835d17df59e606f78b..2b84704ac6d0ec0a0bd491b35030f23b2d02f2c2 100644
+--- a/src/main/java/net/minecraft/server/ItemWrittenBook.java
++++ b/src/main/java/net/minecraft/server/ItemWrittenBook.java
+@@ -49,7 +49,7 @@ public class ItemWrittenBook extends Item {
+         if (itemstack != null && itemstack.getTag() != null) {
+             NBTTagCompound nbttagcompound = itemstack.getTag();
+ 
+-            if (!nbttagcompound.getBoolean("resolved")) {
++            if (com.hpfxd.pandaspigot.config.PandaSpigotConfig.get().resolveSelectorsInBooks && !nbttagcompound.getBoolean("resolved")) { // PandaSpigot
+                 nbttagcompound.setBoolean("resolved", true);
+                 if (b(nbttagcompound)) {
+                     NBTTagList nbttaglist = nbttagcompound.getList("pages", 8);


### PR DESCRIPTION
Disabling this function prevents some exploits (even the newly discovered exploit using books).