### PR TITLE
Backport "Better handling of some ItemMeta" patch

### DIFF
--- a/patches/server/0065-Backport-SPIGOT-5428-Better-handling-of-some-ItemMet.patch
+++ b/patches/server/0065-Backport-SPIGOT-5428-Better-handling-of-some-ItemMet.patch
@@ -1,0 +1,64 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mathias <mail@mathias.is>
+Date: Mon, 16 Dec 2019 19:11:10 +0200
+Subject: [PATCH] Backport SPIGOT-5428: Better handling of some ItemMeta
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
+index 80f9ffa9bb5c1acfa52019ca5c3e261580a1e148..27131ccf83e8cf9f35f2f74235da524a7e73d7d4 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
+@@ -52,7 +52,14 @@ public class CraftMetaBanner extends CraftMetaItem implements BannerMeta {
+             NBTTagList patterns = entityTag.getList(PATTERNS.NBT, 10);
+             for (int i = 0; i < Math.min(patterns.size(), 20); i++) {
+                 NBTTagCompound p = patterns.get(i);
+-                this.patterns.add(new Pattern(DyeColor.getByDyeData((byte) p.getInt(COLOR.NBT)), PatternType.getByIdentifier(p.getString(PATTERN.NBT))));
++                // PandaSpigot - Backport SPIGOT-5428
++                DyeColor color = DyeColor.getByDyeData((byte) p.getInt(COLOR.NBT));
++                PatternType pattern = PatternType.getByIdentifier(p.getString(PATTERN.NBT));
++
++                if (color != null && pattern != null) {
++                    this.patterns.add(new Pattern(color, pattern));
++                }
++                // PandaSpigot end
+             }
+         }
+     }
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaCharge.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaCharge.java
+index 6c6fde739d9d96117a33adb266c5ed14bcdd91d1..9e188d9a07edaadee42eec564889702752abfb35 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaCharge.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaCharge.java
+@@ -36,7 +36,13 @@ class CraftMetaCharge extends CraftMetaItem implements FireworkEffectMeta {
+         super(tag);
+ 
+         if (tag.hasKey(EXPLOSION.NBT)) {
+-            effect = CraftMetaFirework.getEffect(tag.getCompound(EXPLOSION.NBT));
++            // PandaSpigot start - Backport SPIGOT-5428
++            try {
++                effect = CraftMetaFirework.getEffect(tag.getCompound(EXPLOSION.NBT));
++            } catch (IllegalArgumentException ex) {
++                // Ignore invalid effects
++            }
++            // PandaSpigot end
+         }
+     }
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaFirework.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaFirework.java
+index 5a409aebbb483c3327c2517ba1ee1a05a8f696fa..62d43088a02f019c7b2c9607478451857080995d 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaFirework.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaFirework.java
+@@ -92,7 +92,13 @@ class CraftMetaFirework extends CraftMetaItem implements FireworkMeta {
+         List<FireworkEffect> effects = this.effects = new ArrayList<FireworkEffect>(fireworkEffects.size());
+ 
+         for (int i = 0; i < fireworkEffects.size(); i++) {
+-            effects.add(getEffect((NBTTagCompound) fireworkEffects.get(i)));
++            // PandaSpigot start - Backport SPIGOT-5428
++            try {
++                effects.add(getEffect((NBTTagCompound) fireworkEffects.get(i)));
++            } catch (IllegalArgumentException ex) {
++                // Ignore invalid effects
++            }
++            // PandaSpigot end
+         }
+     }
+ 

--- a/patches/server/0065-Backport-SPIGOT-5428-Better-handling-of-some-ItemMet.patch
+++ b/patches/server/0065-Backport-SPIGOT-5428-Better-handling-of-some-ItemMet.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Backport SPIGOT-5428: Better handling of some ItemMeta
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
-index 80f9ffa9bb5c1acfa52019ca5c3e261580a1e148..27131ccf83e8cf9f35f2f74235da524a7e73d7d4 100644
+index 80f9ffa9bb5c1acfa52019ca5c3e261580a1e148..d6fd5bf82d9c8ef34eb4af014399ef36177991b6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
 @@ -52,7 +52,14 @@ public class CraftMetaBanner extends CraftMetaItem implements BannerMeta {
@@ -13,7 +13,7 @@ index 80f9ffa9bb5c1acfa52019ca5c3e261580a1e148..27131ccf83e8cf9f35f2f74235da524a
              for (int i = 0; i < Math.min(patterns.size(), 20); i++) {
                  NBTTagCompound p = patterns.get(i);
 -                this.patterns.add(new Pattern(DyeColor.getByDyeData((byte) p.getInt(COLOR.NBT)), PatternType.getByIdentifier(p.getString(PATTERN.NBT))));
-+                // PandaSpigot - Backport SPIGOT-5428
++                // PandaSpigot start - Backport SPIGOT-5428
 +                DyeColor color = DyeColor.getByDyeData((byte) p.getInt(COLOR.NBT));
 +                PatternType pattern = PatternType.getByIdentifier(p.getString(PATTERN.NBT));
 +


### PR DESCRIPTION
Avoid using items with invalid effects and patterns to disconnect players.

Original patch: https://github.com/PaperMC/Paper/blob/ver/1.13.2/Spigot-Server-Patches/0447-Backport-SPIGOT-5428-Better-handling-of-some-ItemMet.patch <- NOTE: Fixes for CraftMetaMap/Potion not implemented due to non-extension of color implementation in their classes in 1.8.