### PR TITLE
Backport TacoSpigot fix to ProtocolSupport plugin (Fix issue #29)

### DIFF
--- a/patches/server/0066-Fix-issue-with-ProtocolSupport.patch
+++ b/patches/server/0066-Fix-issue-with-ProtocolSupport.patch
@@ -29,14 +29,16 @@ index 0000000000000000000000000000000000000000..77274a982bb3537020689f45bac86923
 +}
 \ No newline at end of file
 diff --git a/src/main/java/net/minecraft/server/PacketDataSerializer.java b/src/main/java/net/minecraft/server/PacketDataSerializer.java
-index 6c46349fb24856bb2b0f94d84536f64d96daeece..60107fe183cb1e6afdb908d326dd52372c461752 100644
+index 6c46349fb24856bb2b0f94d84536f64d96daeece..ca71c3eecd8fb67ac26f253ca9c6682041e39f19 100644
 --- a/src/main/java/net/minecraft/server/PacketDataSerializer.java
 +++ b/src/main/java/net/minecraft/server/PacketDataSerializer.java
-@@ -31,7 +31,19 @@ public class PacketDataSerializer extends ByteBuf {
+@@ -31,7 +31,21 @@ public class PacketDataSerializer extends ByteBuf {
  
      private final ByteBuf a;
  
-+    // PandaSpigot start
++    // PandaSpigot start - large packet limit
++    private static final int DEFAULT_LIMIT = Short.MAX_VALUE;
++    private static final int LARGE_PACKET_LIMIT = Short.MAX_VALUE * 1024;
 +    private final boolean allowLargePackets;
      public PacketDataSerializer(ByteBuf bytebuf) {
 +        /*
@@ -48,23 +50,16 @@ index 6c46349fb24856bb2b0f94d84536f64d96daeece..60107fe183cb1e6afdb908d326dd5237
 +         * which would leave the server vulnerable to packets up to 2 GIGABYTES in size.
 +         */
 +        this.allowLargePackets = com.hpfxd.pandaspigot.CompatHacks.hasProtocolSupport();
-+        // PandaSpigot end
++    // PandaSpigot end
          this.a = bytebuf;
      }
  
-@@ -50,12 +62,17 @@ public class PacketDataSerializer extends ByteBuf {
-         this.writeBytes(abyte);
-     }
+@@ -52,10 +66,10 @@ public class PacketDataSerializer extends ByteBuf {
  
-+    // PandaSpigot start
-+    private static final int DEFAULT_LIMIT = Short.MAX_VALUE;
-+    private static final int LARGE_PACKET_LIMIT = Short.MAX_VALUE * 1024;
      // Paper start
      public byte[] a() {
 -        return readByteArray(Short.MAX_VALUE);
-+        int limit = allowLargePackets ? LARGE_PACKET_LIMIT : DEFAULT_LIMIT;
-+        return readByteArray(limit);
-+        // PandaSpigot end
++        return readByteArray(this.allowLargePackets ? LARGE_PACKET_LIMIT : DEFAULT_LIMIT); // PandaSpigot - large packet limit
      }
  
 -    public byte[]readByteArray(int limit) {

--- a/patches/server/0066-Fix-issue-with-ProtocolSupport.patch
+++ b/patches/server/0066-Fix-issue-with-ProtocolSupport.patch
@@ -3,6 +3,13 @@ From: Thinkofdeath <thinkofdeath@spigotmc.org>
 Date: Wed, 19 Oct 2022 19:21:01 -0300
 Subject: [PATCH] Fix issue with ProtocolSupport
 
+This is a particularly severe/exploitable issue -- clients can send packets forcing the server to allocate any valid array size, without actually sending any data for it to fill. This is fixed by limiting the size of read byte arrays to at most Short.MAX_VALUE (31 KB).
+
+However, we have to make an exception for 1.7 ProtocolSupport clients,
+or they will crash. For them we limit the packets to 31 MB, which should
+still be plenty although it leaves the server slightly more vulnearable.
+
+The arrays in encryption packets are limited to 256 bytes.
 
 diff --git a/src/main/java/com/hpfxd/pandaspigot/CompatHacks.java b/src/main/java/com/hpfxd/pandaspigot/CompatHacks.java
 new file mode 100644

--- a/patches/server/0066-Fix-issue-with-ProtocolSupport.patch
+++ b/patches/server/0066-Fix-issue-with-ProtocolSupport.patch
@@ -29,18 +29,10 @@ index 0000000000000000000000000000000000000000..77274a982bb3537020689f45bac86923
 +}
 \ No newline at end of file
 diff --git a/src/main/java/net/minecraft/server/PacketDataSerializer.java b/src/main/java/net/minecraft/server/PacketDataSerializer.java
-index 6c46349fb24856bb2b0f94d84536f64d96daeece..c224114f0374644b1c92d3cd5868ea4da9ff271f 100644
+index 6c46349fb24856bb2b0f94d84536f64d96daeece..60107fe183cb1e6afdb908d326dd52372c461752 100644
 --- a/src/main/java/net/minecraft/server/PacketDataSerializer.java
 +++ b/src/main/java/net/minecraft/server/PacketDataSerializer.java
-@@ -26,12 +26,27 @@ import java.nio.channels.FileChannel;
- // PandaSpigot end
- 
- import org.bukkit.craftbukkit.inventory.CraftItemStack; // CraftBukkit
-+// PandaSpigot start
-+import com.hpfxd.pandaspigot.CompatHacks;
-+// PandaSpigot end
- 
- public class PacketDataSerializer extends ByteBuf {
+@@ -31,7 +31,19 @@ public class PacketDataSerializer extends ByteBuf {
  
      private final ByteBuf a;
  
@@ -55,12 +47,12 @@ index 6c46349fb24856bb2b0f94d84536f64d96daeece..c224114f0374644b1c92d3cd5868ea4d
 +         * it's still much better than the old system of having no limit,
 +         * which would leave the server vulnerable to packets up to 2 GIGABYTES in size.
 +         */
-+        this.allowLargePackets = CompatHacks.hasProtocolSupport();
++        this.allowLargePackets = com.hpfxd.pandaspigot.CompatHacks.hasProtocolSupport();
 +        // PandaSpigot end
          this.a = bytebuf;
      }
  
-@@ -50,12 +65,17 @@ public class PacketDataSerializer extends ByteBuf {
+@@ -50,12 +62,17 @@ public class PacketDataSerializer extends ByteBuf {
          this.writeBytes(abyte);
      }
  

--- a/patches/server/0066-Fix-issue-with-ProtocolSupport.patch
+++ b/patches/server/0066-Fix-issue-with-ProtocolSupport.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: uRyanxD <familiarodrigues123ro@gmail.com>
+From: Thinkofdeath <thinkofdeath@spigotmc.org>
 Date: Wed, 19 Oct 2022 19:21:01 -0300
 Subject: [PATCH] Fix issue with ProtocolSupport
 

--- a/patches/server/0066-Fix-issue-with-ProtocolSupport.patch
+++ b/patches/server/0066-Fix-issue-with-ProtocolSupport.patch
@@ -29,7 +29,7 @@ index 0000000000000000000000000000000000000000..77274a982bb3537020689f45bac86923
 +}
 \ No newline at end of file
 diff --git a/src/main/java/net/minecraft/server/PacketDataSerializer.java b/src/main/java/net/minecraft/server/PacketDataSerializer.java
-index 6c46349fb24856bb2b0f94d84536f64d96daeece..ca71c3eecd8fb67ac26f253ca9c6682041e39f19 100644
+index 6c46349fb24856bb2b0f94d84536f64d96daeece..ad33280bb8baab581a4ac17b5fe78022134c676b 100644
 --- a/src/main/java/net/minecraft/server/PacketDataSerializer.java
 +++ b/src/main/java/net/minecraft/server/PacketDataSerializer.java
 @@ -31,7 +31,21 @@ public class PacketDataSerializer extends ByteBuf {
@@ -54,7 +54,7 @@ index 6c46349fb24856bb2b0f94d84536f64d96daeece..ca71c3eecd8fb67ac26f253ca9c66820
          this.a = bytebuf;
      }
  
-@@ -52,10 +66,10 @@ public class PacketDataSerializer extends ByteBuf {
+@@ -52,7 +66,7 @@ public class PacketDataSerializer extends ByteBuf {
  
      // Paper start
      public byte[] a() {
@@ -62,8 +62,4 @@ index 6c46349fb24856bb2b0f94d84536f64d96daeece..ca71c3eecd8fb67ac26f253ca9c66820
 +        return readByteArray(this.allowLargePackets ? LARGE_PACKET_LIMIT : DEFAULT_LIMIT); // PandaSpigot - large packet limit
      }
  
--    public byte[]readByteArray(int limit) {
-+    public byte[] readByteArray(int limit) { // PandaSpigot - fix space
-         int len = this.e();
-         if (len > limit) throw new DecoderException("The received a byte array longer than allowed " + len + " > " + limit);
-         byte[] abyte = new byte[len];
+     public byte[]readByteArray(int limit) {

--- a/patches/server/0066-Fix-issue-with-ProtocolSupport.patch
+++ b/patches/server/0066-Fix-issue-with-ProtocolSupport.patch
@@ -1,0 +1,75 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: uRyanxD <familiarodrigues123ro@gmail.com>
+Date: Wed, 19 Oct 2022 19:21:01 -0300
+Subject: [PATCH] Fix issue with ProtocolSupport
+
+
+diff --git a/src/main/java/com/hpfxd/pandaspigot/CompatHacks.java b/src/main/java/com/hpfxd/pandaspigot/CompatHacks.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..77274a982bb3537020689f45bac86923079b6be0
+--- /dev/null
++++ b/src/main/java/com/hpfxd/pandaspigot/CompatHacks.java
+@@ -0,0 +1,10 @@
++package com.hpfxd.pandaspigot;
++
++import org.bukkit.Bukkit;
++
++public class CompatHacks {
++    private CompatHacks() {}
++    public static boolean hasProtocolSupport() {
++        return Bukkit.getPluginManager().isPluginEnabled("ProtocolSupport");
++    }
++}
+\ No newline at end of file
+diff --git a/src/main/java/net/minecraft/server/PacketDataSerializer.java b/src/main/java/net/minecraft/server/PacketDataSerializer.java
+index 6c46349fb24856bb2b0f94d84536f64d96daeece..c224114f0374644b1c92d3cd5868ea4da9ff271f 100644
+--- a/src/main/java/net/minecraft/server/PacketDataSerializer.java
++++ b/src/main/java/net/minecraft/server/PacketDataSerializer.java
+@@ -26,12 +26,27 @@ import java.nio.channels.FileChannel;
+ // PandaSpigot end
+ 
+ import org.bukkit.craftbukkit.inventory.CraftItemStack; // CraftBukkit
++// PandaSpigot start
++import com.hpfxd.pandaspigot.CompatHacks;
++// PandaSpigot end
+ 
+ public class PacketDataSerializer extends ByteBuf {
+ 
+     private final ByteBuf a;
+ 
++    // PandaSpigot start
++    private final boolean allowLargePackets;
+     public PacketDataSerializer(ByteBuf bytebuf) {
++        /*
++         * By default, we limit the size of the received byte array to Short.MAX_VALUE, which is 31 KB.
++         * However, we make an exception when ProtocolSupport is installed, to allow 1.7 clients to work,
++         * and limit them to 31 MEGABYTES as they seem to need to send larger packets sometimes.
++         * Although a 31 MB limit leaves the server slightly vulnerable,
++         * it's still much better than the old system of having no limit,
++         * which would leave the server vulnerable to packets up to 2 GIGABYTES in size.
++         */
++        this.allowLargePackets = CompatHacks.hasProtocolSupport();
++        // PandaSpigot end
+         this.a = bytebuf;
+     }
+ 
+@@ -50,12 +65,17 @@ public class PacketDataSerializer extends ByteBuf {
+         this.writeBytes(abyte);
+     }
+ 
++    // PandaSpigot start
++    private static final int DEFAULT_LIMIT = Short.MAX_VALUE;
++    private static final int LARGE_PACKET_LIMIT = Short.MAX_VALUE * 1024;
+     // Paper start
+     public byte[] a() {
+-        return readByteArray(Short.MAX_VALUE);
++        int limit = allowLargePackets ? LARGE_PACKET_LIMIT : DEFAULT_LIMIT;
++        return readByteArray(limit);
++        // PandaSpigot end
+     }
+ 
+-    public byte[]readByteArray(int limit) {
++    public byte[] readByteArray(int limit) { // PandaSpigot - fix space
+         int len = this.e();
+         if (len > limit) throw new DecoderException("The received a byte array longer than allowed " + len + " > " + limit);
+         byte[] abyte = new byte[len];

--- a/patches/server/0066-Fix-issue-with-ProtocolSupport.patch
+++ b/patches/server/0066-Fix-issue-with-ProtocolSupport.patch
@@ -13,10 +13,10 @@ The arrays in encryption packets are limited to 256 bytes.
 
 diff --git a/src/main/java/com/hpfxd/pandaspigot/CompatHacks.java b/src/main/java/com/hpfxd/pandaspigot/CompatHacks.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..77274a982bb3537020689f45bac86923079b6be0
+index 0000000000000000000000000000000000000000..c45655f5232934db455aaa5d2d3ff721a5733051
 --- /dev/null
 +++ b/src/main/java/com/hpfxd/pandaspigot/CompatHacks.java
-@@ -0,0 +1,10 @@
+@@ -0,0 +1,11 @@
 +package com.hpfxd.pandaspigot;
 +
 +import org.bukkit.Bukkit;
@@ -27,7 +27,7 @@ index 0000000000000000000000000000000000000000..77274a982bb3537020689f45bac86923
 +        return Bukkit.getPluginManager().isPluginEnabled("ProtocolSupport");
 +    }
 +}
-\ No newline at end of file
++
 diff --git a/src/main/java/net/minecraft/server/PacketDataSerializer.java b/src/main/java/net/minecraft/server/PacketDataSerializer.java
 index 6c46349fb24856bb2b0f94d84536f64d96daeece..ad33280bb8baab581a4ac17b5fe78022134c676b 100644
 --- a/src/main/java/net/minecraft/server/PacketDataSerializer.java


### PR DESCRIPTION
Paper has already added a great deal of this patch, it just hasn't added the workaround for ProtocolSupport to work properly.

https://github.com/TacoSpigot/TacoSpigot/blob/version/1.8.8/PaperSpigot-Server-Patches/0018-Limit-the-length-of-buffered-bytes-to-read.patch