### PR TITLE
Add config option for logging player ip addresses

### DIFF
--- a/patches/server/0067-Add-config-option-for-logging-player-ip-addresses.patch
+++ b/patches/server/0067-Add-config-option-for-logging-player-ip-addresses.patch
@@ -1,0 +1,61 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Noah van der Aa <ndvdaa@gmail.com>
+Date: Tue, 5 Oct 2021 20:04:21 +0200
+Subject: [PATCH] Add config option for logging player ip addresses
+
+
+diff --git a/src/main/java/com/hpfxd/pandaspigot/config/PandaSpigotConfig.java b/src/main/java/com/hpfxd/pandaspigot/config/PandaSpigotConfig.java
+index 8d071fdd1ae8aaa97003f0b56d7e206e6dd4b44f..ae3cdaca275b1a50c5c37c3dd0021c4bd579d373 100644
+--- a/src/main/java/com/hpfxd/pandaspigot/config/PandaSpigotConfig.java
++++ b/src/main/java/com/hpfxd/pandaspigot/config/PandaSpigotConfig.java
+@@ -121,4 +121,8 @@ public class PandaSpigotConfig {
+     public PacketLimiterConfig packetLimiter = PacketLimiterConfig.createDefault();
+ 
+     public boolean resolveSelectorsInBooks = true;
++
++    @Comment("Whether player IP addresses should be logged by the server. This does not impact\n" +
++        "the ability of plugins to log the IP addresses of players.")
++    public boolean logPlayerIpAddresses = true;
+ }
+diff --git a/src/main/java/net/minecraft/server/LoginListener.java b/src/main/java/net/minecraft/server/LoginListener.java
+index b32c64263d6d996008d0aa3b25df1d8d54482aa1..9faa98501275cbd03a34dcc83f281d1e3f40a6e0 100644
+--- a/src/main/java/net/minecraft/server/LoginListener.java
++++ b/src/main/java/net/minecraft/server/LoginListener.java
+@@ -158,7 +158,10 @@ public class LoginListener implements PacketLoginInListener, IUpdatePlayerListBo
+     }
+ 
+     public String d() {
+-        return this.i != null ? this.i.toString() + " (" + this.networkManager.getSocketAddress().toString() + ")" : String.valueOf(this.networkManager.getSocketAddress());
++        // PandaSpigot start
++        String ip = com.hpfxd.pandaspigot.config.PandaSpigotConfig.get().logPlayerIpAddresses ? this.networkManager.getSocketAddress().toString() : "<ip address withheld>";
++        return this.i != null ? this.i.toString() + " (" + ip + ")" : ip;
++        // PandaSpigot end
+     }
+ 
+     public void a(PacketLoginInStart packetlogininstart) {
+diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
+index 55e6a1755b7db3411865f1d0ad3b4c38cb66d0a8..9882c599533d8ef52369efb6404a967e736548e0 100644
+--- a/src/main/java/net/minecraft/server/PlayerList.java
++++ b/src/main/java/net/minecraft/server/PlayerList.java
+@@ -119,7 +119,7 @@ public abstract class PlayerList {
+         String s1 = "local";
+ 
+         if (networkmanager.getSocketAddress() != null) {
+-            s1 = networkmanager.getSocketAddress().toString();
++            s1 = com.hpfxd.pandaspigot.config.PandaSpigotConfig.get().logPlayerIpAddresses ? networkmanager.getSocketAddress().toString() : "<ip address withheld>"; // PandaSpigot
+         }
+ 
+         // Spigot start - spawn location event
+diff --git a/src/main/java/net/minecraft/server/ServerConnection.java b/src/main/java/net/minecraft/server/ServerConnection.java
+index 36b5c37d5224ac4f474b5e48767e32f689f6681c..3401addb448a9c731aec768edbe1008e9df80d17 100644
+--- a/src/main/java/net/minecraft/server/ServerConnection.java
++++ b/src/main/java/net/minecraft/server/ServerConnection.java
+@@ -198,7 +198,7 @@ public class ServerConnection {
+                                 throw new ReportedException(crashreport);
+                             }
+ 
+-                            ServerConnection.e.warn("Failed to handle packet for " + networkmanager.getSocketAddress(), exception);
++                            ServerConnection.e.warn("Failed to handle packet for " + (com.hpfxd.pandaspigot.config.PandaSpigotConfig.get().logPlayerIpAddresses ? networkmanager.getSocketAddress() : "<ip address withheld>"), exception); // PandaSpigot
+                             final ChatComponentText chatcomponenttext = new ChatComponentText("Internal server error");
+ 
+                             networkmanager.a(new PacketPlayOutKickDisconnect(chatcomponenttext), new GenericFutureListener() {


### PR DESCRIPTION
Backport of [Paper-0753: Add config option for logging player ip addresses](https://github.com/PaperMC/Paper/blob/b3b04f2ca109979cd9aebd8e7859decbeeba10d4/patches/server/0753-Add-config-option-for-logging-player-ip-addresses.patch).

Closes #32 