### PR TITLE
Modern tick loop cleanup and fixes

### DIFF
--- a/patches/server/0004-Backport-modern-tick-loop.patch
+++ b/patches/server/0004-Backport-modern-tick-loop.patch
@@ -231,7 +231,7 @@ index 088beb22b53ddf77dc182dd5ac39e1086d5279aa..6434b8613971a228fb0074390d8223bf
          Thread thread = new Thread("Server Infinisleeper") {
              {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..2f1e55be489f478d4e173c06f34a8afbecccfaa2 100644
+index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..35ed8ca8f5c40f73c0256b48c0350f437a140f01 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -48,7 +48,7 @@ import org.bukkit.craftbukkit.Main;
@@ -314,7 +314,7 @@ index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..2f1e55be489f478d4e173c06f34a8afb
  
                  this.r.setMOTD(new ChatComponentText(this.motd));
                  this.r.setServerInfo(new ServerPing.ServerData("1.8.8", 47));
-@@ -572,33 +610,22 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+@@ -572,31 +610,21 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
                  // PaperSpigot start - Further improve tick loop
                  Arrays.fill( recentTps, 20 );
                  //long lastTick = System.nanoTime(), catchupTime = 0, curTime, wait, tickSection = lastTick;
@@ -345,7 +345,7 @@ index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..2f1e55be489f478d4e173c06f34a8afb
 -                        wait = TICK_TIME - (curTime - lastTick);
 +                    // PandaSpigot start - Modern tick loop
 +                    long i = ((curTime = System.nanoTime()) / (1000L * 1000L)) - this.nextTickTime; // Paper
-+                    if (i > 5000L && this.nextTickTime - this.lastOverloadWarning >= 30000L) { // CraftBukkit
++                    if (i > 5000L && this.nextTickTime - this.lastOverloadWarning >= 30000L && ticks > 500) { // CraftBukkit
 +                        long j = i / 50L;
 +                        if (this.server.getWarnOnOverload()) // CraftBukkit
 +                            MinecraftServer.LOGGER.warn("Can't keep up! Is the server overloaded? Running {}ms or {} ticks behind", i, j);
@@ -355,13 +355,10 @@ index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..2f1e55be489f478d4e173c06f34a8afb
 -
 -                    catchupTime = Math.min(MAX_CATCHUP_BUFFER, catchupTime - wait);
 -
--                    if ( ++MinecraftServer.currentTick % SAMPLE_INTERVAL == 0 )
--                    {
-+                    if (++MinecraftServer.currentTick % MinecraftServer.SAMPLE_INTERVAL == 0) {
+                     if ( ++MinecraftServer.currentTick % SAMPLE_INTERVAL == 0 )
+                     {
                          final long diff = curTime - tickSection;
-                         double currentTps = 1E9 / diff * SAMPLE_INTERVAL;
-                         tps1.add(currentTps, diff);
-@@ -613,8 +640,16 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+@@ -613,8 +641,16 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
                      }
                      lastTick = curTime;
  
@@ -380,7 +377,7 @@ index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..2f1e55be489f478d4e173c06f34a8afb
                  }
                  // Spigot end
              } else {
-@@ -665,6 +700,62 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+@@ -665,6 +701,62 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
          }
  
      }
@@ -443,7 +440,7 @@ index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..2f1e55be489f478d4e173c06f34a8afb
  
      private void a(ServerPing serverping) {
          File file = this.d("server-icon.png");
-@@ -698,9 +789,15 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+@@ -698,9 +790,15 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
  
      protected void z() {}
  
@@ -460,7 +457,7 @@ index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..2f1e55be489f478d4e173c06f34a8afb
  
          ++this.ticks;
          if (this.T) {
-@@ -744,6 +841,11 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+@@ -744,6 +842,11 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
              SpigotTimings.worldSaveTimer.stopTiming(); // Spigot
          }
  
@@ -472,22 +469,31 @@ index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..2f1e55be489f478d4e173c06f34a8afb
          this.methodProfiler.a("tallying");
          this.h[this.ticks % 100] = System.nanoTime() - i;
          this.methodProfiler.b();
-@@ -981,6 +1083,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
-             });
-             */
+@@ -897,6 +1000,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+         this.p.add(iupdateplayerlistbox);
+     }
  
-+            /* // PandaSpigot start - comment out
-             DedicatedServer dedicatedserver = new DedicatedServer(options);
++    /* // PandaSpigot start - comment out
+     public static void main(final OptionSet options) { // CraftBukkit - replaces main(String[] astring)
+         DispenserRegistry.c();
  
-             if (options.has("port")) {
-@@ -1000,6 +1103,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
- 
-             dedicatedserver.primaryThread.start();
-             // CraftBukkit end
-+            */ // PandaSpigot end
-         } catch (Exception exception) {
-             MinecraftServer.LOGGER.fatal("Failed to start the minecraft server", exception);
+@@ -1005,6 +1109,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
          }
+ 
+     }
++    */ // PandaSpigot end
+ 
+     public void C() {
+         /* CraftBukkit start - prevent abuse
+@@ -1483,7 +1588,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+     }
+ 
+     public static long az() {
+-        return System.currentTimeMillis();
++        return getMillis(); // PandaSpigot - Modern tick loop
+     }
+ 
+     public int getIdleTimeout() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
 index c936219196ea403a9d247ad6c8c0ffee79411da2..5c980fe2907d2ff01be793ab0654ab198f46e519 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java

--- a/patches/server/0004-Backport-modern-tick-loop.patch
+++ b/patches/server/0004-Backport-modern-tick-loop.patch
@@ -231,7 +231,7 @@ index 088beb22b53ddf77dc182dd5ac39e1086d5279aa..6434b8613971a228fb0074390d8223bf
          Thread thread = new Thread("Server Infinisleeper") {
              {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..35ed8ca8f5c40f73c0256b48c0350f437a140f01 100644
+index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..eae936650fddd5ef418ee2ddd680d36e82045365 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -48,7 +48,7 @@ import org.bukkit.craftbukkit.Main;
@@ -469,22 +469,22 @@ index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..35ed8ca8f5c40f73c0256b48c0350f43
          this.methodProfiler.a("tallying");
          this.h[this.ticks % 100] = System.nanoTime() - i;
          this.methodProfiler.b();
-@@ -897,6 +1000,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
-         this.p.add(iupdateplayerlistbox);
-     }
+@@ -981,6 +1084,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+             });
+             */
  
-+    /* // PandaSpigot start - comment out
-     public static void main(final OptionSet options) { // CraftBukkit - replaces main(String[] astring)
-         DispenserRegistry.c();
++            /* // PandaSpigot start - comment out
+             DedicatedServer dedicatedserver = new DedicatedServer(options);
  
-@@ -1005,6 +1109,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+             if (options.has("port")) {
+@@ -1000,6 +1104,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+ 
+             dedicatedserver.primaryThread.start();
+             // CraftBukkit end
++            */ // PandaSpigot end
+         } catch (Exception exception) {
+             MinecraftServer.LOGGER.fatal("Failed to start the minecraft server", exception);
          }
- 
-     }
-+    */ // PandaSpigot end
- 
-     public void C() {
-         /* CraftBukkit start - prevent abuse
 @@ -1483,7 +1588,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
      }
  

--- a/patches/server/0012-Consolidate-flush-calls-for-entity-tracker-packets.patch
+++ b/patches/server/0012-Consolidate-flush-calls-for-entity-tracker-packets.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Consolidate flush calls for entity tracker packets
 Most server packets seem to be sent from here, so try to avoid expensive flush calls from them.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 21744e05b564d61956eeacb639aa4d9ef69d419f..221559ddba319e5357c1ba6a930ddd8d3303c39d 100644
+index 35ed8ca8f5c40f73c0256b48c0350f437a140f01..c7b6bc4eb4103af9e3385b88984271a009ef5afc 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -962,7 +962,26 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
+@@ -963,7 +963,26 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
                  this.methodProfiler.b();
                  this.methodProfiler.a("tracker");
                  worldserver.timings.tracker.startTiming(); // Spigot

--- a/patches/server/0016-Optimize-World-Time-Updates.patch
+++ b/patches/server/0016-Optimize-World-Time-Updates.patch
@@ -8,10 +8,10 @@ the updates per world, so that we can re-use the same packet
 object for every player unless they have per-player time enabled.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 221559ddba319e5357c1ba6a930ddd8d3303c39d..ec145f5551193ee9898c7b344b22fd725c2b054d 100644
+index c7b6bc4eb4103af9e3385b88984271a009ef5afc..f5bd918aad71d8f1c24c39bb786ef91eed7372b2 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -898,12 +898,24 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
+@@ -899,12 +899,24 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
  
          SpigotTimings.timeUpdateTimer.startTiming(); // Spigot
          // Send time updates to everyone, it will get the right time from the world the player is in.

--- a/patches/server/0017-Configurable-time-update-frequency.patch
+++ b/patches/server/0017-Configurable-time-update-frequency.patch
@@ -23,10 +23,10 @@ index 0e781b78cb37bd85f9f753bd351d7c724a561bd7..023820936a0684c97fefb115e7ab10d3
      public KnockbackConfig knockback;
      
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index ec145f5551193ee9898c7b344b22fd725c2b054d..12eb4fd70c12a6294ac4ed25fcc61087a4b2d7dc 100644
+index f5bd918aad71d8f1c24c39bb786ef91eed7372b2..9e3bb94f11263c4614f18c282ae236d03599619a 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -905,7 +905,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
+@@ -906,7 +906,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
              long worldTime = world.getTime();
              final PacketPlayOutUpdateTime worldPacket = new PacketPlayOutUpdateTime(worldTime, dayTime, doDaylight);
              for (EntityHuman entityhuman : world.players) {

--- a/patches/server/0022-EntityMoveEvent.patch
+++ b/patches/server/0022-EntityMoveEvent.patch
@@ -32,10 +32,10 @@ index 72c7e6fc8bb0a71877d6759af44d39030bcf51f5..cd95aa17291d31e3cebe9f6488a43923
  
      protected void doTick() {}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 12eb4fd70c12a6294ac4ed25fcc61087a4b2d7dc..a2020d0f3a44d8402874ee6886972d15d42f3751 100644
+index 9e3bb94f11263c4614f18c282ae236d03599619a..f6d1510fc16fc48be221cc7bb5968a132a2b9752 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -925,6 +925,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
+@@ -926,6 +926,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
  
              // if (i == 0 || this.getAllowNether()) {
                  WorldServer worldserver = this.worlds.get(i);

--- a/patches/server/0030-Cleanup-allocated-favicon-ByteBuf.patch
+++ b/patches/server/0030-Cleanup-allocated-favicon-ByteBuf.patch
@@ -7,10 +7,10 @@ Cleanups a bytebuffer which was allocated during the encoding of the
 favicon to be sent to the client.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index a2020d0f3a44d8402874ee6886972d15d42f3751..b784f8174b94c6fab41ed3262009383a2ffba3cc 100644
+index f6d1510fc16fc48be221cc7bb5968a132a2b9752..faf566f647d161160c6c01ae4fa500f38dc61b8c 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -762,6 +762,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
+@@ -763,6 +763,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
  
          if (file.isFile()) {
              ByteBuf bytebuf = Unpooled.buffer();
@@ -18,7 +18,7 @@ index a2020d0f3a44d8402874ee6886972d15d42f3751..b784f8174b94c6fab41ed3262009383a
  
              try {
                  BufferedImage bufferedimage = ImageIO.read(file);
-@@ -769,13 +770,14 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
+@@ -770,13 +771,14 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
                  Validate.validState(bufferedimage.getWidth() == 64, "Must be 64 pixels wide", new Object[0]);
                  Validate.validState(bufferedimage.getHeight() == 64, "Must be 64 pixels high", new Object[0]);
                  ImageIO.write(bufferedimage, "PNG", new ByteBufOutputStream(bytebuf));

--- a/patches/server/0036-Backport-PlayerProfile-API.patch
+++ b/patches/server/0036-Backport-PlayerProfile-API.patch
@@ -320,10 +320,10 @@ index 9034e1ad7a013c7288e68322a65798e40d8b851d..86ab9994079c6e18e3aed885db4171d0
      public EntityFishingHook hookedFish;
      public boolean affectsSpawning = true; // PaperSpigot
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 26f1e07cefd54afe3df1b8ce8e4d58b26619c8d3..795967ca7369220a6602c3b31d006aa00f6924c7 100644
+index 3b408b82ba482282b44214ea57769e9b79c5671d..ca182cd6cf4a6e86ffb7074524f587642fddd66c 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1640,6 +1640,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
+@@ -1641,6 +1641,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
          return true;
      }
  
@@ -365,7 +365,7 @@ index 0f82e06cba1c245846b665ee00ab9a6e388884d3..474f43eab7ceb63ab04e2ebbcdd9f73d
          UserCache.UserCacheEntry usercache_usercacheentry = (UserCache.UserCacheEntry) this.d.get(uuid);
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7da53bccec38c626005c9d7f81096763a8a3d95e..46b8316f7d5a7c226890367acf174fa6c3341fb8 100644
+index 1caffab6e75abf6010e8f1f2d2a29a2a22692fb7..e218b127c6dcdce2c4f8154684f58d4295c6c247 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1769,6 +1769,27 @@ public final class CraftServer implements Server {

--- a/patches/server/0040-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0040-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -234,7 +234,7 @@ index 09085582a95fc4c61034db70dd543c5e7da8ede7..cd22366c7b066494192e0602da174701
          System.setOut(new PrintStream(new LoggerOutputStream(logger, Level.INFO), true));
          System.setErr(new PrintStream(new LoggerOutputStream(logger, Level.WARN), true));
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 27eda2ca8fe1fce9cc7635bf4cc1f7fd193c118e..fdfe1163e721474bce54cf5c11a69ea9bdd9e9bd 100644
+index ca182cd6cf4a6e86ffb7074524f587642fddd66c..d71dc092fd9bd33e885b7421421c0ea5cc22efb3 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -41,7 +41,7 @@ import org.apache.logging.log4j.Logger;
@@ -271,7 +271,7 @@ index 27eda2ca8fe1fce9cc7635bf4cc1f7fd193c118e..fdfe1163e721474bce54cf5c11a69ea9
          Runtime.getRuntime().addShutdownHook(new org.bukkit.craftbukkit.util.ServerShutdownThread(this));
  
          //this.serverThread = primaryThread = new Thread(this, "Server thread"); // Moved from main // PandaSpigot - comment out; we assign above
-@@ -690,7 +692,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
+@@ -691,7 +693,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
              } finally {
                  // CraftBukkit start - Restore terminal to original settings
                  try {
@@ -280,7 +280,7 @@ index 27eda2ca8fe1fce9cc7635bf4cc1f7fd193c118e..fdfe1163e721474bce54cf5c11a69ea9
                  } catch (Exception ignored) {
                  }
                  // CraftBukkit end
-@@ -1308,7 +1310,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
+@@ -1309,7 +1311,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
      }
  
      public void sendMessage(IChatBaseComponent ichatbasecomponent) {

--- a/patches/server/0047-Only-process-BlockPhysicsEvent-if-a-plugin-has-a-lis.patch
+++ b/patches/server/0047-Only-process-BlockPhysicsEvent-if-a-plugin-has-a-lis.patch
@@ -19,10 +19,10 @@ index c1110242136e8fd98661886920b765bb5367c37d..81fc97dc295677f5c2914e8c9b97a3f4
              org.bukkit.block.Block block = world.getWorld().getBlockAt(blockposition.getX(), blockposition.getY(), blockposition.getZ());
              BlockPhysicsEvent event = new BlockPhysicsEvent(block, block.getTypeId());
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 33f1661bdcb14b2a1b2cc95e14077baec09d2342..dfa3f3f4e2aaef934b6adcd5e865a6964b2b7cc8 100644
+index d71dc092fd9bd33e885b7421421c0ea5cc22efb3..5a3f3f762754374b0635b959c381aeffa682f56e 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -930,6 +930,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
+@@ -931,6 +931,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
              // if (i == 0 || this.getAllowNether()) {
                  WorldServer worldserver = this.worlds.get(i);
                  worldserver.hasEntityMoveEvent = io.papermc.paper.event.entity.EntityMoveEvent.getHandlerList().getRegisteredListeners().length > 0; // PandaSpigot

--- a/patches/server/0072-Skip-updating-entity-tracker-if-server-is-empty.patch
+++ b/patches/server/0072-Skip-updating-entity-tracker-if-server-is-empty.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Skip updating entity tracker if server is empty
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index d7b2b64affff6079eaed67b3e4229afb975289ae..450efa52b71e3b8cc9f03a08132dd864499a9fb5 100644
+index 5a3f3f762754374b0635b959c381aeffa682f56e..4aed68b628bd66731540f0e0b5a649717bc3c3ac 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -992,7 +992,9 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
+@@ -993,7 +993,9 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
                  }
                  try {
                  // PandaSpigot end


### PR DESCRIPTION
Changes:
 1: Cleanup
 2: Don't display overload message after server startup (https://github.com/Wind-Development/WindSpigot/commit/1b9d1a7926e68ff4a0da8ef21deba6cf60de22ac & https://github.com/Wind-Development/WindSpigot/commit/7190cd5733f8a7246a3588b336200c3776784589)
 3: Add missing change in az() method (https://github.com/Wind-Development/WindSpigot/commit/b735e19966c7119ce92e510f915d0c58de705374#diff-a1d5ab453d81fa6035e2465e8e84ffdb13fba514310caee493a15e71afad72cbR1593)
 
 Fixes #95