### PR TITLE
add overlooked parts of optimize network patch

### DIFF
--- a/patches/server/0010-Optimize-Network-Manager-and-add-advanced-packet-sup.patch
+++ b/patches/server/0010-Optimize-Network-Manager-and-add-advanced-packet-sup.patch
@@ -26,7 +26,7 @@ Also avoids spamming closed channel exception by rechecking closed state in disp
 and then catch exceptions and close if they fire.
 
 diff --git a/src/main/java/net/minecraft/server/NetworkManager.java b/src/main/java/net/minecraft/server/NetworkManager.java
-index 8f8b9aa731f2c97a3e32369bfd4d641a1f2ab412..e46ed015ba584a84af52ab8a33d83e2b80a00851 100644
+index 8f8b9aa731f2c97a3e32369bfd4d641a1f2ab412..f6e797f712f029a9bbe94739469c7464cdb7ed19 100644
 --- a/src/main/java/net/minecraft/server/NetworkManager.java
 +++ b/src/main/java/net/minecraft/server/NetworkManager.java
 @@ -62,7 +62,7 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet> {
@@ -139,7 +139,7 @@ index 8f8b9aa731f2c97a3e32369bfd4d641a1f2ab412..e46ed015ba584a84af52ab8a33d83e2b
 +                MinecraftServer.getServer().isMainThread() && packet.isReady() && this.i.isEmpty() &&
 +                        (packet.getExtraPackets() == null || packet.getExtraPackets().isEmpty())
 +        ))) {
-+            this.dispatchPacket(packet, listeners);
++            this.writePacket(packet, listeners,null);
 +            return;
 +        }
 +        // write the packets to the queue, then flush - antixray hooks there already
@@ -287,7 +287,7 @@ index 8f8b9aa731f2c97a3e32369bfd4d641a1f2ab412..e46ed015ba584a84af52ab8a33d83e2b
 +            NetworkManager.QueuedPacket queued = iterator.next(); // poll -> peek
 +    
 +            // Fix NPE (Spigot bug caused by handleDisconnection())
-+            if (queued == null) return true;
++            if (false && queued == null) return true;
 +    
 +            Packet<?> packet = queued.getPacket();
 +            if (!packet.isReady()) {


### PR DESCRIPTION
when testing with bots 100-200 with movement and swing options
saw that the netty threads where always very busy/looked like getting overloaded from profiling

upon further investigation it looked like these parts where ported over from later versions
and now they aren't overloaded 

even teleporting 100 bots to your location and they instantly started to move again on client
compared to the server almost crashing before from overloading on the flushing of the queued packets that where waiting to be processed or be sent back


also these changes where in the spotted patch so they might have been missed/overlooked


