### PR TITLE
Remap final jar using Spigot deprecation mappings

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -9,4 +9,5 @@ repositories {
 
 dependencies {
     implementation("io.sigpipe:jbsdiff:1.0")
+    implementation("net.md-5:SpecialSource:1.11.3")
 }

--- a/build-logic/src/main/kotlin/ArchiveName.kt
+++ b/build-logic/src/main/kotlin/ArchiveName.kt
@@ -1,0 +1,44 @@
+import org.gradle.api.tasks.bundling.AbstractArchiveTask
+
+/*
+ * Included from https://github.com/typst-io/gradle-specialsource
+ * Original project licensed under Apache 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+ */
+data class ArchiveName(
+    val baseName: String,
+    val appendix: String,
+    val version: String,
+    val classifier: String,
+    val extension: String
+) {
+    fun toFileName(): String =
+        listOf(
+            baseName,
+            appendix,
+            version,
+            classifier
+        ).filter {
+            it.isNotEmpty()
+        }.joinToString("-") + if (extension.isNotEmpty()) {
+            ".${extension}"
+        } else ""
+
+    companion object {
+        @JvmStatic
+        fun jar(name: String, version: String, classifier: String): ArchiveName =
+            ArchiveName(name, "", version, classifier, "jar")
+
+        @JvmStatic
+        fun simpleJar(name: String, version: String): ArchiveName =
+            jar(name, version, "")
+
+        fun archiveNameFromTask(x: AbstractArchiveTask): ArchiveName =
+            ArchiveName(
+                x.archiveBaseName.orNull ?: "",
+                x.archiveAppendix.orNull ?: "",
+                x.archiveVersion.orNull ?: "",
+                x.archiveClassifier.orNull ?: "",
+                x.archiveExtension.orNull ?: ""
+            )
+    }
+}

--- a/build-logic/src/main/kotlin/RemapTask.kt
+++ b/build-logic/src/main/kotlin/RemapTask.kt
@@ -1,0 +1,98 @@
+import net.md_5.specialsource.AccessMap
+import net.md_5.specialsource.Jar
+import net.md_5.specialsource.JarMapping
+import net.md_5.specialsource.JarRemapper
+import net.md_5.specialsource.RemapperProcessor
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.SkipWhenEmpty
+import org.gradle.api.tasks.TaskAction
+
+/*
+ * Included from https://github.com/typst-io/gradle-specialsource - modified to add support for specifying an access
+ * transformer to pass to SpecialSource. Original project licensed under Apache 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+ */
+/**
+ * Java bytecode remap task.
+ *
+ * This task uses and following [md-5's SpecialSource.](https://github.com/md-5/specialsource)
+ *
+ * Command-line arguments: [SpecialSource.java](https://github.com/md-5/SpecialSource/blob/master/src/main/java/net/md_5/specialsource/SpecialSource.java#L63)
+ *
+ * @author typst-io
+ */
+abstract class RemapTask : DefaultTask() {
+    /**
+     * Inputs a source jar file as `RegularFile`. Mandatory.
+     *
+     * Corresponding cmd-line args:
+     *
+     * ```-i ${inJarFile}```
+     */
+    @get:InputFile
+    @get:SkipWhenEmpty
+    abstract val inJarFile: RegularFileProperty
+
+    /**
+     * Inputs a destination dir. Mandatory.
+     */
+    @get:OutputFile
+    abstract val outJarFile: RegularFileProperty
+
+    /**
+     * Input a mapping file as `RegularFile`. Mandatory.
+     *
+     * Corresponding cmd-line args:
+     *
+     * ```-srg-in ${mappingFile}```
+     */
+    @get:InputFile
+    abstract val mappingFile: RegularFileProperty
+
+    /**
+     * Input an access transformer file as `RegularFile`.
+     *
+     * Corresponding cmd-line args:
+     *
+     * ```-access-transformer ${accessTransformer}```
+     */
+    @get:InputFile
+    @get:Optional
+    abstract val accessTransformerFile: RegularFileProperty
+
+    /**
+     * Input whether reverse or not. Defaults to `false`.
+     *
+     * Corresponding cmd-line args:
+     *
+     * ```-reverse```
+     */
+    @get:Input
+    @get:Optional
+    abstract val reverse: Property<Boolean>
+
+    @TaskAction
+    fun remap() {
+        val mapping = JarMapping()
+        val rev = reverse.getOrElse(false)
+
+        val mappingPath = mappingFile.asFile.get().absolutePath
+        mapping.loadMappings(mappingPath, rev, false, null, null)
+
+        val accessMapper = accessTransformerFile.orNull?.let {
+            val access = AccessMap()
+            access.loadAccessTransformer(it.asFile)
+            RemapperProcessor(null, mapping, access)
+        }
+
+        val jarMap = JarRemapper(null, mapping, accessMapper)
+        Jar.init(inJarFile.asFile.get()).use { jar ->
+            jarMap.remapJar(jar, outJarFile.get().asFile)
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/RemapTask.kt
+++ b/build-logic/src/main/kotlin/RemapTask.kt
@@ -3,6 +3,7 @@ import net.md_5.specialsource.Jar
 import net.md_5.specialsource.JarMapping
 import net.md_5.specialsource.JarRemapper
 import net.md_5.specialsource.RemapperProcessor
+import net.md_5.specialsource.provider.JarProvider
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
@@ -92,6 +93,7 @@ abstract class RemapTask : DefaultTask() {
 
         val jarMap = JarRemapper(null, mapping, accessMapper)
         Jar.init(inJarFile.asFile.get()).use { jar ->
+            mapping.setFallbackInheritanceProvider(JarProvider(jar))
             jarMap.remapJar(jar, outJarFile.get().asFile)
         }
     }

--- a/build-logic/src/main/kotlin/paperclip.gradle.kts
+++ b/build-logic/src/main/kotlin/paperclip.gradle.kts
@@ -8,7 +8,7 @@ import java.util.Properties
 tasks {
     register<Jar>("paperclipJar") {
         outputs.upToDateWhen { false }
-        dependsOn("shadowJar", ":pandaspigot-server:shadowJar")
+        dependsOn("shadowJar", ":pandaspigot-server:remap")
 
         from(zipTree((tasks["shadowJar"] as Jar).archiveFile.get()))
 
@@ -25,12 +25,12 @@ tasks {
         }
 
         doFirst {
-            val shadowTask = project(":pandaspigot-server").tasks["shadowJar"] as Jar
+            val inTask = project(":pandaspigot-server").tasks["remap"] as RemapTask
             val diffFile = temporaryDir.resolve("pandaspigot.patch")
             val propertiesFile = temporaryDir.resolve("patch.properties")
 
             val vanillaJar = project.rootProject.layout.projectDirectory.file("base/mc-dev/1.8.8.jar").asFile
-            val newJar = shadowTask.archiveFile.get().asFile
+            val newJar = inTask.outJarFile.get().asFile
 
             logger.info("Reading jars into memory")
             val vanillaBytes = Files.readAllBytes(vanillaJar.toPath())

--- a/patches/server/0003-Setup-Gradle-project.patch
+++ b/patches/server/0003-Setup-Gradle-project.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Setup Gradle project
 
 diff --git a/build.gradle.kts b/build.gradle.kts
 new file mode 100644
-index 0000000000000000000000000000000000000000..3938905ca58c3d1cd1db4fa9632637b7a43ff8c5
+index 0000000000000000000000000000000000000000..c751b21fcf9b6b30b6546179ca11c9f6319f3370
 --- /dev/null
 +++ b/build.gradle.kts
-@@ -0,0 +1,114 @@
+@@ -0,0 +1,132 @@
 +plugins {
 +    id("pandaspigot.conventions")
 +    id("com.github.johnrengelman.shadow") version "7.1.2"
@@ -67,7 +67,7 @@ index 0000000000000000000000000000000000000000..3938905ca58c3d1cd1db4fa9632637b7
 +tasks {
 +    shadowJar {
 +        mergeServiceFiles()
-+        archiveClassifier.set("") // without "-all"
++        archiveClassifier.set("unmapped")
 +
 +        val cbLibsPkg = "org.bukkit.craftbukkit.libs"
 +
@@ -123,108 +123,25 @@ index 0000000000000000000000000000000000000000..3938905ca58c3d1cd1db4fa9632637b7
 +        classpath = java.sourceSets.main.get().runtimeClasspath
 +        mainClass.set("org.bukkit.craftbukkit.Main")
 +    }
++
++    register<RemapTask>("remap") {
++        description = "Remap the output JAR file using the deprecation mappings"
++
++        val inTask = shadowJar.get()
++        inJarFile.set(inTask.archiveFile)
++        outJarFile.set(inTask.destinationDirectory.map { dir ->
++            val archiveName = ArchiveName.archiveNameFromTask(inTask).copy(classifier = "")
++            dir.file(archiveName.toFileName())
++        })
++
++        mappingFile.set(project.layout.projectDirectory.file("deprecation-mappings.csrg"))
++        accessTransformerFile.set(project.layout.projectDirectory.file("deprecation-mappings.at"))
++    }
++
++    assemble {
++        dependsOn(named("remap"))
++    }
 +}
-diff --git a/deprecation-mappings.at b/deprecation-mappings.at
-deleted file mode 100644
-index 5858b488706682919648deb1aaf32c13d26b95af..0000000000000000000000000000000000000000
---- a/deprecation-mappings.at
-+++ /dev/null
-@@ -1,62 +0,0 @@
--public+synthetic org/bukkit/Bukkit/getOnlinePlayers()[Lorg/bukkit/entity/Player;
--public+synthetic org/bukkit/Server/getOnlinePlayers()[Lorg/bukkit/entity/Player;
--
--public+synthetic org/bukkit/entity/Damageable/damage(I)V
--public+synthetic org/bukkit/entity/Damageable/damage(ILorg/bukkit/entity/Entity;)V
--public+synthetic org/bukkit/entity/Damageable/getHealth()I
--public+synthetic org/bukkit/entity/Damageable/getMaxHealth()I
--public+synthetic org/bukkit/entity/Damageable/setHealth(I)V
--public+synthetic org/bukkit/entity/Damageable/setMaxHealth(I)V
--
--public+synthetic org/bukkit/entity/LivingEntity/getLastDamage()I
--public+synthetic org/bukkit/entity/LivingEntity/setLastDamage(I)V
--
--public+synthetic org/bukkit/entity/Minecart/getDamage()I
--public+synthetic org/bukkit/entity/Minecart/setDamage(I)V
--
--public+synthetic org/bukkit/entity/Projectile/getShooter()Lorg/bukkit/entity/LivingEntity;
--public+synthetic org/bukkit/entity/Projectile/setShooter(Lorg/bukkit/entity/LivingEntity;)V
--
--public+synthetic org/bukkit/event/entity/EntityDamageEvent/getDamage()I
--public+synthetic org/bukkit/event/entity/EntityDamageEvent/setDamage(I)V
--
--public+synthetic org/bukkit/event/entity/EntityRegainHealthEvent/getAmount()I
--public+synthetic org/bukkit/event/entity/EntityRegainHealthEvent/setAmount(I)V
--
--public+synthetic org/bukkit/event/vehicle/VehicleDamageEvent/getDamage()I
--public+synthetic org/bukkit/event/vehicle/VehicleDamageEvent/setDamage(I)V
--
--# CraftBukkit
--public+synthetic org/bukkit/craftbukkit/v1_8_R3/CraftServer/getOnlinePlayers()[Lorg/bukkit/entity/Player;
--
--public+synthetic org/bukkit/craftbukkit/v1_8_R3/entity/CraftArrow/getShooter()Lorg/bukkit/entity/LivingEntity;
--public+synthetic org/bukkit/craftbukkit/v1_8_R3/entity/CraftArrow/setShooter(Lorg/bukkit/entity/LivingEntity;)V
--
--public+synthetic org/bukkit/craftbukkit/v1_8_R3/entity/CraftEnderDragonPart/damage(I)V
--public+synthetic org/bukkit/craftbukkit/v1_8_R3/entity/CraftEnderDragonPart/damage(ILorg/bukkit/entity/Entity;)V
--public+synthetic org/bukkit/craftbukkit/v1_8_R3/entity/CraftEnderDragonPart/getHealth()I
--public+synthetic org/bukkit/craftbukkit/v1_8_R3/entity/CraftEnderDragonPart/getMaxHealth()I
--public+synthetic org/bukkit/craftbukkit/v1_8_R3/entity/CraftEnderDragonPart/setHealth(I)V
--public+synthetic org/bukkit/craftbukkit/v1_8_R3/entity/CraftEnderDragonPart/setMaxHealth(I)V
--
--
--public+synthetic org/bukkit/craftbukkit/v1_8_R3/entity/CraftFireball/getShooter()Lorg/bukkit/entity/LivingEntity;
--public+synthetic org/bukkit/craftbukkit/v1_8_R3/entity/CraftFireball/setShooter(Lorg/bukkit/entity/LivingEntity;)V
--
--public+synthetic org/bukkit/craftbukkit/v1_8_R3/entity/CraftFish/getShooter()Lorg/bukkit/entity/LivingEntity;
--public+synthetic org/bukkit/craftbukkit/v1_8_R3/entity/CraftFish/setShooter(Lorg/bukkit/entity/LivingEntity;)V
--
--public+synthetic org/bukkit/craftbukkit/v1_8_R3/entity/CraftLivingEntity/damage(I)V
--public+synthetic org/bukkit/craftbukkit/v1_8_R3/entity/CraftLivingEntity/damage(ILorg/bukkit/entity/Entity;)V
--public+synthetic org/bukkit/craftbukkit/v1_8_R3/entity/CraftLivingEntity/getHealth()I
--public+synthetic org/bukkit/craftbukkit/v1_8_R3/entity/CraftLivingEntity/getMaxHealth()I
--public+synthetic org/bukkit/craftbukkit/v1_8_R3/entity/CraftLivingEntity/setHealth(I)V
--public+synthetic org/bukkit/craftbukkit/v1_8_R3/entity/CraftLivingEntity/setMaxHealth(I)V
--public+synthetic org/bukkit/craftbukkit/v1_8_R3/entity/CraftLivingEntity/getLastDamage()I
--public+synthetic org/bukkit/craftbukkit/v1_8_R3/entity/CraftLivingEntity/setLastDamage(I)V
--
--public+synthetic org/bukkit/craftbukkit/v1_8_R3/entity/CraftMinecart/getDamage()I
--public+synthetic org/bukkit/craftbukkit/v1_8_R3/entity/CraftMinecart/setDamage(I)V
--
--public+synthetic org/bukkit/craftbukkit/v1_8_R3/entity/CraftProjectile/getShooter()Lorg/bukkit/entity/LivingEntity;
--public+synthetic org/bukkit/craftbukkit/v1_8_R3/entity/CraftProjectile/setShooter(Lorg/bukkit/entity/LivingEntity;)V
-diff --git a/deprecation-mappings.csrg b/deprecation-mappings.csrg
-deleted file mode 100644
-index 48bc504954dfc5763cae9069aa8cc8f70453e5b0..0000000000000000000000000000000000000000
---- a/deprecation-mappings.csrg
-+++ /dev/null
-@@ -1,27 +0,0 @@
--org/bukkit/Bukkit _INVALID_getOnlinePlayers ()[Lorg/bukkit/entity/Player; getOnlinePlayers
--org/bukkit/Server _INVALID_getOnlinePlayers ()[Lorg/bukkit/entity/Player; getOnlinePlayers
--
--org/bukkit/entity/Damageable _INVALID_damage (I)V damage
--org/bukkit/entity/Damageable _INVALID_damage (ILorg/bukkit/entity/Entity;)V damage
--org/bukkit/entity/Damageable _INVALID_getHealth ()I getHealth
--org/bukkit/entity/Damageable _INVALID_getMaxHealth ()I getMaxHealth
--org/bukkit/entity/Damageable _INVALID_setHealth (I)V setHealth
--org/bukkit/entity/Damageable _INVALID_setMaxHealth (I)V setMaxHealth
--
--org/bukkit/entity/LivingEntity _INVALID_getLastDamage ()I getLastDamage
--org/bukkit/entity/LivingEntity _INVALID_setLastDamage (I)V setLastDamage
--
--org/bukkit/entity/Minecart _INVALID_getDamage ()I getDamage
--org/bukkit/entity/Minecart _INVALID_setDamage (I)V setDamage
--
--org/bukkit/entity/Projectile _INVALID_getShooter ()Lorg/bukkit/entity/LivingEntity; getShooter
--org/bukkit/entity/Projectile _INVALID_setShooter (Lorg/bukkit/entity/LivingEntity;)V setShooter
--
--org/bukkit/event/entity/EntityDamageEvent _INVALID_getDamage ()I getDamage
--org/bukkit/event/entity/EntityDamageEvent _INVALID_setDamage (I)V setDamage
--
--org/bukkit/event/entity/EntityRegainHealthEvent _INVALID_getAmount ()I getAmount
--org/bukkit/event/entity/EntityRegainHealthEvent _INVALID_setAmount (I)V setAmount
--
--org/bukkit/event/vehicle/VehicleDamageEvent _INVALID_getDamage ()I getDamage
--org/bukkit/event/vehicle/VehicleDamageEvent _INVALID_setDamage (I)V setDamage
 diff --git a/pom.xml b/pom.xml
 deleted file mode 100644
 index 644305e68a20f43286c917b15e04a43f05dce254..0000000000000000000000000000000000000000

--- a/patches/server/0006-Update-to-Netty-4.1.x.patch
+++ b/patches/server/0006-Update-to-Netty-4.1.x.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Update to Netty 4.1.x
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 3938905ca58c3d1cd1db4fa9632637b7a43ff8c5..d4896940f221e95a581d067e08d17bddfd4452bf 100644
+index c751b21fcf9b6b30b6546179ca11c9f6319f3370..3e97931d3695e9b4e6aca80842832c65ad44bd06 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -13,7 +13,7 @@ dependencies {
@@ -25,14 +25,14 @@ index 3938905ca58c3d1cd1db4fa9632637b7a43ff8c5..d4896940f221e95a581d067e08d17bdd
      implementation("net.sf.jopt-simple:jopt-simple:3.2")
      implementation("jline:jline:2.12.1")
  
-@@ -55,6 +54,7 @@ fun TaskContainer.registerRunTask(
- tasks {
+@@ -56,6 +55,7 @@ tasks {
      shadowJar {
          mergeServiceFiles()
+         archiveClassifier.set("unmapped")
 +        append("META-INF/io.netty.versions.properties")
-         archiveClassifier.set("") // without "-all"
  
          val cbLibsPkg = "org.bukkit.craftbukkit.libs"
+ 
 diff --git a/src/main/java/net/minecraft/server/PacketDataSerializer.java b/src/main/java/net/minecraft/server/PacketDataSerializer.java
 index e2eb305468ff76026dc9b24d59394cfc94501273..b48eeb63ad61b18a630f2feb4fd6203e5e3e6c80 100644
 --- a/src/main/java/net/minecraft/server/PacketDataSerializer.java

--- a/patches/server/0014-PandaSpigot-Configuration.patch
+++ b/patches/server/0014-PandaSpigot-Configuration.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] PandaSpigot Configuration
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index d4896940f221e95a581d067e08d17bddfd4452bf..cf11ec3fd93471bfcf90c067ac6c5e99ec443965 100644
+index 3e97931d3695e9b4e6aca80842832c65ad44bd06..7c0bac5144853c7258bb65ddf6a0654ca5697269 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -12,6 +12,12 @@ repositories {
@@ -23,8 +23,8 @@ index d4896940f221e95a581d067e08d17bddfd4452bf..cf11ec3fd93471bfcf90c067ac6c5e99
      implementation("com.mojang:authlib:1.5.21")
 @@ -56,6 +62,13 @@ tasks {
          mergeServiceFiles()
+         archiveClassifier.set("unmapped")
          append("META-INF/io.netty.versions.properties")
-         archiveClassifier.set("") // without "-all"
 +        // PandaSpigot start - Configuration
 +        arrayOf(
 +            "com.amihaiemil.eoyaml",

--- a/patches/server/0040-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0040-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -22,7 +22,7 @@ This patch contains heavy inspiration from:
 https://github.com/PaperMC/Paper/blob/master/patches/server/0137-Use-TerminalConsoleAppender-for-console-improvements.patch
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index cf11ec3fd93471bfcf90c067ac6c5e99ec443965..59a51ba28c0ce8bb86ed9fd8896ea051f01c7771 100644
+index 7c0bac5144853c7258bb65ddf6a0654ca5697269..22b69df26679d07893224314d16483aa83b42004 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -21,8 +21,10 @@ dependencies {
@@ -55,14 +55,14 @@ index cf11ec3fd93471bfcf90c067ac6c5e99ec443965..59a51ba28c0ce8bb86ed9fd8896ea051
      testImplementation("junit:junit:4.11")
      testImplementation("org.hamcrest:hamcrest-library:1.3")
  }
-@@ -61,6 +67,7 @@ tasks {
-     shadowJar {
+@@ -62,6 +68,7 @@ tasks {
          mergeServiceFiles()
+         archiveClassifier.set("unmapped")
          append("META-INF/io.netty.versions.properties")
 +        transform(com.github.jengelman.gradle.plugins.shadow.transformers.Log4j2PluginsCacheFileTransformer()) // PandaSpigot - Use TerminalConsoleAppender
-         archiveClassifier.set("") // without "-all"
          // PandaSpigot start - Configuration
          arrayOf(
+             "com.amihaiemil.eoyaml",
 diff --git a/src/main/java/com/hpfxd/pandaspigot/console/PandaConsole.java b/src/main/java/com/hpfxd/pandaspigot/console/PandaConsole.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..25a515b681bbbb70946f2ec73647a6f184f81b3c


### PR DESCRIPTION
This patch re-introduces the remapping of `_INVALID_` deprecated methods performed by upstream, as well as transforming old `int` health-related setters to have the synthetic modifier (plugins should be using the `double` methods).
This is done to provide binary compatibility with plugins built against very old versions of the Bukkit API.

This implementation for PandaSpigot uses a modified version of the [`RemapTask` in `gradle-specialsource`](https://github.com/typst-io/gradle-specialsource/blob/8b038c46d1b9e8a6a523ad7278c4b07b078650dd/src/main/kotlin/io/typecraft/gradlesource/RemapTask.kt), licensed under Apache 2.0.

Fixes #7, #152, #159, #174, #178