### PR TITLE
Fix console messages being black by default

### DIFF
--- a/patches/server/0040-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0040-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -234,7 +234,7 @@ index 09085582a95fc4c61034db70dd543c5e7da8ede7..cd22366c7b066494192e0602da174701
          System.setOut(new PrintStream(new LoggerOutputStream(logger, Level.INFO), true));
          System.setErr(new PrintStream(new LoggerOutputStream(logger, Level.WARN), true));
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 75716099df3c3afc9e5857258ed6d1b271c4b957..7cdc9d1451a4f85b99095db7e7e4ddb187ae12dc 100644
+index 75716099df3c3afc9e5857258ed6d1b271c4b957..baeb16f594eb4cedb05e6336a950cf23942153a2 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -41,7 +41,7 @@ import org.apache.logging.log4j.Logger;
@@ -285,7 +285,7 @@ index 75716099df3c3afc9e5857258ed6d1b271c4b957..7cdc9d1451a4f85b99095db7e7e4ddb1
  
      public void sendMessage(IChatBaseComponent ichatbasecomponent) {
 -        MinecraftServer.LOGGER.info(ichatbasecomponent.c());
-+        MinecraftServer.LOGGER.info(org.bukkit.craftbukkit.util.CraftChatMessage.fromComponent(ichatbasecomponent)); // PandaSpigot - Log messages with color
++        MinecraftServer.LOGGER.info(org.bukkit.craftbukkit.util.CraftChatMessage.fromComponent(ichatbasecomponent, net.minecraft.server.EnumChatFormat.WHITE)); // PandaSpigot - Log messages with color
      }
  
      public boolean a(int i, String s) {


### PR DESCRIPTION
Fix #204

I wasted a lot of time trying to find the problem, which was so obvious, initially I tried to put WHITE here like in Paper, but I put the ) in the wrong place and that's why it didn't work lol