### PR TITLE
Fix and cleanup modern tick loop

### DIFF
--- a/patches/server/0004-Backport-modern-tick-loop.patch
+++ b/patches/server/0004-Backport-modern-tick-loop.patch
@@ -231,7 +231,7 @@ index 088beb22b53ddf77dc182dd5ac39e1086d5279aa..6434b8613971a228fb0074390d8223bf
          Thread thread = new Thread("Server Infinisleeper") {
              {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..15202423fba6a0661222a00be2c0aa1b5d64e906 100644
+index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..67f74c2def3517939142ac07f31ec94621d8edc0 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -48,7 +48,7 @@ import org.bukkit.craftbukkit.Main;
@@ -248,7 +248,7 @@ index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..15202423fba6a0661222a00be2c0aa1b
      protected final Queue<FutureTask<?>> j = new java.util.concurrent.ConcurrentLinkedQueue<FutureTask<?>>(); // Spigot, PAIL: Rename
      private Thread serverThread;
 -    private long ab = az();
-+    private long ab; // PandaSpigot - Initializer az() is redundant
++    private long ab; // PandaSpigot - The az() initializer is redundant
  
      // CraftBukkit start
      public List<WorldServer> worlds = new ArrayList<WorldServer>();

--- a/patches/server/0004-Backport-modern-tick-loop.patch
+++ b/patches/server/0004-Backport-modern-tick-loop.patch
@@ -231,7 +231,7 @@ index 088beb22b53ddf77dc182dd5ac39e1086d5279aa..6434b8613971a228fb0074390d8223bf
          Thread thread = new Thread("Server Infinisleeper") {
              {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..eae936650fddd5ef418ee2ddd680d36e82045365 100644
+index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..15202423fba6a0661222a00be2c0aa1b5d64e906 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -48,7 +48,7 @@ import org.bukkit.craftbukkit.Main;
@@ -243,13 +243,21 @@ index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..eae936650fddd5ef418ee2ddd680d36e
  
      public static final Logger LOGGER = LogManager.getLogger();
      public static final File a = new File("usercache.json");
-@@ -117,7 +117,36 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+@@ -102,7 +102,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+     private final UserCache Z;
+     protected final Queue<FutureTask<?>> j = new java.util.concurrent.ConcurrentLinkedQueue<FutureTask<?>>(); // Spigot, PAIL: Rename
+     private Thread serverThread;
+-    private long ab = az();
++    private long ab; // PandaSpigot - Initializer az() is redundant
+ 
+     // CraftBukkit start
+     public List<WorldServer> worlds = new ArrayList<WorldServer>();
+@@ -117,7 +117,35 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
      public int autosavePeriod;
      // CraftBukkit end
  
 -    public MinecraftServer(OptionSet options, Proxy proxy, File file1) {
 +    // PandaSpigot start - Modern tick loop
-+    private long nextTickTime;
 +    private long delayedTasksMaxNextTickTime;
 +    private boolean mayHaveDelayedTasks;
 +    private boolean forceTicks;
@@ -274,14 +282,14 @@ index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..eae936650fddd5ef418ee2ddd680d36e
 +
 +    public MinecraftServer(OptionSet options, Proxy proxy, File file1, Thread thread) {
 +        super("Server");
-+        this.nextTickTime = getMillis();
++        this.ab = az();
 +        this.primaryThread = thread;
 +        this.serverThread = thread;
 +    // PandaSpigot end
          io.netty.util.ResourceLeakDetector.setEnabled( false ); // Spigot - disable
          this.e = proxy;
          MinecraftServer.l = this;
-@@ -154,7 +183,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+@@ -154,7 +182,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
          }
          Runtime.getRuntime().addShutdownHook(new org.bukkit.craftbukkit.util.ServerShutdownThread(this));
  
@@ -290,22 +298,16 @@ index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..eae936650fddd5ef418ee2ddd680d36e
      }
  
      public abstract PropertyManager getPropertyManager();
-@@ -557,12 +586,21 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+@@ -557,12 +585,15 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
          }
      }
      // PaperSpigot End
 - 
 +
 +    // PandaSpigot start - Modern tick loop
-+    public static long getMillis() {
-+        return getNanos() / 1000000L;
-+    }
-+    public static long getNanos() {
-+        return System.nanoTime();
-+    }
      public void run() {
          try {
-+            this.serverStartTime = getNanos();
++            this.serverStartTime = az();
 +    // PandaSpigot end
              if (this.init()) {
                  this.ab = az();
@@ -314,7 +316,7 @@ index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..eae936650fddd5ef418ee2ddd680d36e
  
                  this.r.setMOTD(new ChatComponentText(this.motd));
                  this.r.setServerInfo(new ServerPing.ServerData("1.8.8", 47));
-@@ -572,31 +610,21 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+@@ -572,31 +603,21 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
                  // PaperSpigot start - Further improve tick loop
                  Arrays.fill( recentTps, 20 );
                  //long lastTick = System.nanoTime(), catchupTime = 0, curTime, wait, tickSection = lastTick;
@@ -344,13 +346,13 @@ index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..eae936650fddd5ef418ee2ddd680d36e
 -                        Thread.sleep(wait / 1000000);
 -                        wait = TICK_TIME - (curTime - lastTick);
 +                    // PandaSpigot start - Modern tick loop
-+                    long i = ((curTime = System.nanoTime()) / (1000L * 1000L)) - this.nextTickTime; // Paper
-+                    if (i > 5000L && this.nextTickTime - this.lastOverloadWarning >= 30000L && ticks > 500) { // CraftBukkit
++                    long i = ((curTime = System.nanoTime()) / (1000L * 1000L)) - ab;
++                    if (i > 5000L && this.ab - this.lastOverloadWarning >= 30000L && ticks > 500) {
 +                        long j = i / 50L;
 +                        if (this.server.getWarnOnOverload()) // CraftBukkit
 +                            MinecraftServer.LOGGER.warn("Can't keep up! Is the server overloaded? Running {}ms or {} ticks behind", i, j);
-+                        this.nextTickTime += j * 50L;
-+                        this.lastOverloadWarning = this.nextTickTime;
++                        this.ab += j * 50L;
++                        this.lastOverloadWarning = this.ab;
                      }
 -
 -                    catchupTime = Math.min(MAX_CATCHUP_BUFFER, catchupTime - wait);
@@ -358,18 +360,20 @@ index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..eae936650fddd5ef418ee2ddd680d36e
                      if ( ++MinecraftServer.currentTick % SAMPLE_INTERVAL == 0 )
                      {
                          final long diff = curTime - tickSection;
-@@ -613,8 +641,16 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+@@ -612,9 +633,17 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+                         // PaperSpigot end
                      }
                      lastTick = curTime;
- 
+-
 -                    this.A();
 -                    this.Q = true;
-+                    this.nextTickTime += 50L;
++                    this.ab += 50L;
++
 +                    this.methodProfiler.a("tick");
 +                    this.A(this::haveTime);
 +                    this.methodProfiler.c("nextTickWait");
 +                    this.mayHaveDelayedTasks = true;
-+                    this.delayedTasksMaxNextTickTime = Math.max(getMillis() + 50L, this.nextTickTime);
++                    this.delayedTasksMaxNextTickTime = Math.max(az() + 50L, this.ab);
 +                    this.waitUntilNextTick();
 +                    this.methodProfiler.b();
 +                    this.isReady = true;
@@ -377,23 +381,23 @@ index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..eae936650fddd5ef418ee2ddd680d36e
                  }
                  // Spigot end
              } else {
-@@ -665,6 +701,62 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+@@ -665,6 +694,62 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
          }
  
      }
 +    // PandaSpigot start - Modern tick loop
 +    private boolean haveTime() {
 +        if (isOversleep) return canOversleep();
-+        return this.forceTicks || this.runningTask() || getMillis() < (this.mayHaveDelayedTasks ? this.delayedTasksMaxNextTickTime : this.nextTickTime);
++        return this.forceTicks || this.runningTask() || az() < (this.mayHaveDelayedTasks ? this.delayedTasksMaxNextTickTime : this.ab);
 +    }
 +
 +    boolean isOversleep = false;
 +    private boolean canOversleep() {
-+        return this.mayHaveDelayedTasks && getMillis() < this.delayedTasksMaxNextTickTime;
++        return this.mayHaveDelayedTasks && az() < this.delayedTasksMaxNextTickTime;
 +    }
 +
 +    private boolean canSleepForTickNoOversleep() {
-+        return this.forceTicks || this.runningTask() || getMillis() < this.nextTickTime;
++        return this.forceTicks || this.runningTask() || az() < this.ab;
 +    }
 +
 +    private void executeModerately() {
@@ -440,7 +444,7 @@ index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..eae936650fddd5ef418ee2ddd680d36e
  
      private void a(ServerPing serverping) {
          File file = this.d("server-icon.png");
-@@ -698,9 +790,15 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+@@ -698,9 +783,15 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
  
      protected void z() {}
  
@@ -457,7 +461,7 @@ index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..eae936650fddd5ef418ee2ddd680d36e
  
          ++this.ticks;
          if (this.T) {
-@@ -744,6 +842,11 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+@@ -744,6 +835,11 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
              SpigotTimings.worldSaveTimer.stopTiming(); // Spigot
          }
  
@@ -469,7 +473,7 @@ index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..eae936650fddd5ef418ee2ddd680d36e
          this.methodProfiler.a("tallying");
          this.h[this.ticks % 100] = System.nanoTime() - i;
          this.methodProfiler.b();
-@@ -981,6 +1084,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+@@ -981,6 +1077,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
              });
              */
  
@@ -477,7 +481,7 @@ index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..eae936650fddd5ef418ee2ddd680d36e
              DedicatedServer dedicatedserver = new DedicatedServer(options);
  
              if (options.has("port")) {
-@@ -1000,6 +1104,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+@@ -1000,6 +1097,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
  
              dedicatedserver.primaryThread.start();
              // CraftBukkit end
@@ -485,15 +489,36 @@ index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..eae936650fddd5ef418ee2ddd680d36e
          } catch (Exception exception) {
              MinecraftServer.LOGGER.fatal("Failed to start the minecraft server", exception);
          }
-@@ -1483,7 +1588,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+@@ -1483,7 +1581,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
      }
  
      public static long az() {
 -        return System.currentTimeMillis();
-+        return getMillis(); // PandaSpigot - Modern tick loop
++        return SystemUtils.getMonotonicMillis(); // PandaSpigot - Modern tick loop
      }
  
      public int getIdleTimeout() {
+diff --git a/src/main/java/net/minecraft/server/SystemUtils.java b/src/main/java/net/minecraft/server/SystemUtils.java
+index e65ffc1566784f8a35a4a620514375b9077ce247..6f328c24a2f00ad07163cd7964be111b526414df 100644
+--- a/src/main/java/net/minecraft/server/SystemUtils.java
++++ b/src/main/java/net/minecraft/server/SystemUtils.java
+@@ -6,6 +6,16 @@ import org.apache.logging.log4j.Logger;
+ 
+ public class SystemUtils {
+ 
++    // PandaSpigot start - Modern Tick Loop
++    public static long getMonotonicMillis() {
++        return getMonotonicNanos() / 1000000L;
++    }
++
++    public static long getMonotonicNanos() {
++        return System.nanoTime(); // Paper
++    }
++    // PandaSpigot end
++
+     public static <V> V a(FutureTask<V> futuretask, Logger logger) {
+         try {
+             futuretask.run();
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
 index c936219196ea403a9d247ad6c8c0ffee79411da2..5c980fe2907d2ff01be793ab0654ab198f46e519 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java

--- a/patches/server/0004-Backport-modern-tick-loop.patch
+++ b/patches/server/0004-Backport-modern-tick-loop.patch
@@ -495,7 +495,7 @@ index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..f411b611fc8b35fc60882d0123f01de4
  
      public int getIdleTimeout() {
 diff --git a/src/main/java/net/minecraft/server/SystemUtils.java b/src/main/java/net/minecraft/server/SystemUtils.java
-index e65ffc1566784f8a35a4a620514375b9077ce247..6f328c24a2f00ad07163cd7964be111b526414df 100644
+index e65ffc1566784f8a35a4a620514375b9077ce247..0c23e540a300590f967a681a3a8cf65bfc4f1377 100644
 --- a/src/main/java/net/minecraft/server/SystemUtils.java
 +++ b/src/main/java/net/minecraft/server/SystemUtils.java
 @@ -6,6 +6,16 @@ import org.apache.logging.log4j.Logger;
@@ -508,7 +508,7 @@ index e65ffc1566784f8a35a4a620514375b9077ce247..6f328c24a2f00ad07163cd7964be111b
 +    }
 +
 +    public static long getMonotonicNanos() {
-+        return System.nanoTime(); // Paper
++        return System.nanoTime();
 +    }
 +    // PandaSpigot end
 +

--- a/patches/server/0004-Backport-modern-tick-loop.patch
+++ b/patches/server/0004-Backport-modern-tick-loop.patch
@@ -231,7 +231,7 @@ index 088beb22b53ddf77dc182dd5ac39e1086d5279aa..6434b8613971a228fb0074390d8223bf
          Thread thread = new Thread("Server Infinisleeper") {
              {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..67f74c2def3517939142ac07f31ec94621d8edc0 100644
+index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..f411b611fc8b35fc60882d0123f01de49380b4b0 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -48,7 +48,7 @@ import org.bukkit.craftbukkit.Main;
@@ -298,12 +298,10 @@ index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..67f74c2def3517939142ac07f31ec946
      }
  
      public abstract PropertyManager getPropertyManager();
-@@ -557,12 +585,15 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
-         }
+@@ -558,11 +586,14 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
      }
      // PaperSpigot End
-- 
-+
+  
 +    // PandaSpigot start - Modern tick loop
      public void run() {
          try {
@@ -341,10 +339,6 @@ index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..67f74c2def3517939142ac07f31ec946
 -                            wait -= catchupTime;
 -                            catchupTime -= catchupTime;
 -                        }
--                    }
--                    if (wait > 0) {
--                        Thread.sleep(wait / 1000000);
--                        wait = TICK_TIME - (curTime - lastTick);
 +                    // PandaSpigot start - Modern tick loop
 +                    long i = ((curTime = System.nanoTime()) / (1000L * 1000L)) - ab;
 +                    if (i > 5000L && this.ab - this.lastOverloadWarning >= 30000L && ticks > 500) {
@@ -354,21 +348,23 @@ index 7d19ec833d61c2f75b5eb75d7eb291c7366a1a9a..67f74c2def3517939142ac07f31ec946
 +                        this.ab += j * 50L;
 +                        this.lastOverloadWarning = this.ab;
                      }
+-                    if (wait > 0) {
+-                        Thread.sleep(wait / 1000000);
+-                        wait = TICK_TIME - (curTime - lastTick);
+-                    }
 -
 -                    catchupTime = Math.min(MAX_CATCHUP_BUFFER, catchupTime - wait);
 -
                      if ( ++MinecraftServer.currentTick % SAMPLE_INTERVAL == 0 )
                      {
                          final long diff = curTime - tickSection;
-@@ -612,9 +633,17 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
-                         // PaperSpigot end
+@@ -613,8 +634,16 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
                      }
                      lastTick = curTime;
--
+ 
 -                    this.A();
 -                    this.Q = true;
 +                    this.ab += 50L;
-+
 +                    this.methodProfiler.a("tick");
 +                    this.A(this::haveTime);
 +                    this.methodProfiler.c("nextTickWait");

--- a/patches/server/0013-Consolidate-flush-calls-for-entity-tracker-packets.patch
+++ b/patches/server/0013-Consolidate-flush-calls-for-entity-tracker-packets.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Consolidate flush calls for entity tracker packets
 Most server packets seem to be sent from here, so try to avoid expensive flush calls from them.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index eae936650fddd5ef418ee2ddd680d36e82045365..06e023994050a07d2efed174b1fbd8f1eddcd231 100644
+index 15202423fba6a0661222a00be2c0aa1b5d64e906..7e6bad78c9b7a05d1def63a77610fd6c332b8c85 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -963,7 +963,26 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
+@@ -956,7 +956,26 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
                  this.methodProfiler.b();
                  this.methodProfiler.a("tracker");
                  worldserver.timings.tracker.startTiming(); // Spigot

--- a/patches/server/0017-Optimize-World-Time-Updates.patch
+++ b/patches/server/0017-Optimize-World-Time-Updates.patch
@@ -8,10 +8,10 @@ the updates per world, so that we can re-use the same packet
 object for every player unless they have per-player time enabled.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 06e023994050a07d2efed174b1fbd8f1eddcd231..8f394d5fe6f0f0640a942f15ae69582bfd70b4c8 100644
+index 7e6bad78c9b7a05d1def63a77610fd6c332b8c85..f213f9db49acb9efff02178556d6eec969f4d9c1 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -899,12 +899,24 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
+@@ -892,12 +892,24 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
  
          SpigotTimings.timeUpdateTimer.startTiming(); // Spigot
          // Send time updates to everyone, it will get the right time from the world the player is in.

--- a/patches/server/0018-Configurable-time-update-frequency.patch
+++ b/patches/server/0018-Configurable-time-update-frequency.patch
@@ -23,10 +23,10 @@ index 3dd3d0702c17541083d0d365ca46e93602105bce..b5f16e8cab9e43ad7597b2ea5bc92139
      public KnockbackConfig knockback;
      
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 8f394d5fe6f0f0640a942f15ae69582bfd70b4c8..b7decb879f530345b82722aeb1294864feecd2c2 100644
+index f213f9db49acb9efff02178556d6eec969f4d9c1..eafa8ca822b79c8f31e43b484ce27b500a979bf5 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -906,7 +906,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
+@@ -899,7 +899,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
              long worldTime = world.getTime();
              final PacketPlayOutUpdateTime worldPacket = new PacketPlayOutUpdateTime(worldTime, dayTime, doDaylight);
              for (EntityHuman entityhuman : world.players) {

--- a/patches/server/0023-EntityMoveEvent.patch
+++ b/patches/server/0023-EntityMoveEvent.patch
@@ -31,10 +31,10 @@ index 72c7e6fc8bb0a71877d6759af44d39030bcf51f5..1353a791235ae3b820072fa80ef60c3c
  
      protected void doTick() {}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index b7decb879f530345b82722aeb1294864feecd2c2..66d4c410c2bcc345bf09e07a63de7534064524d2 100644
+index eafa8ca822b79c8f31e43b484ce27b500a979bf5..5a0cf1ba4d7f7fbc9b62a60201682244e5dd56ff 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -926,6 +926,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
+@@ -919,6 +919,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
  
              // if (i == 0 || this.getAllowNether()) {
                  WorldServer worldserver = this.worlds.get(i);

--- a/patches/server/0030-Cleanup-allocated-favicon-ByteBuf.patch
+++ b/patches/server/0030-Cleanup-allocated-favicon-ByteBuf.patch
@@ -7,10 +7,10 @@ Cleanups a bytebuffer which was allocated during the encoding of the
 favicon to be sent to the client.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index f6d1510fc16fc48be221cc7bb5968a132a2b9752..faf566f647d161160c6c01ae4fa500f38dc61b8c 100644
+index 5a0cf1ba4d7f7fbc9b62a60201682244e5dd56ff..348c63892aef13e70f38cbc7989c0b4d994873b9 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -763,6 +763,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
+@@ -756,6 +756,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
  
          if (file.isFile()) {
              ByteBuf bytebuf = Unpooled.buffer();
@@ -18,7 +18,7 @@ index f6d1510fc16fc48be221cc7bb5968a132a2b9752..faf566f647d161160c6c01ae4fa500f3
  
              try {
                  BufferedImage bufferedimage = ImageIO.read(file);
-@@ -770,13 +771,14 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
+@@ -763,13 +764,14 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
                  Validate.validState(bufferedimage.getWidth() == 64, "Must be 64 pixels wide", new Object[0]);
                  Validate.validState(bufferedimage.getHeight() == 64, "Must be 64 pixels high", new Object[0]);
                  ImageIO.write(bufferedimage, "PNG", new ByteBufOutputStream(bytebuf));

--- a/patches/server/0035-Optimize-Network-Queue.patch
+++ b/patches/server/0035-Optimize-Network-Queue.patch
@@ -45,7 +45,7 @@ index 0000000000000000000000000000000000000000..c8540d16defdc633113b504616794f44
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 348c63892aef13e70f38cbc7989c0b4d994873b9..8cfc553b059db22a2deb4c86210edb705d41e2ac 100644
+index e6466f470adddbaf438b98c559a27d5d13bccacd..6392695bf426536709967f744d511ed9de823a96 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -100,7 +100,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
@@ -55,5 +55,5 @@ index 348c63892aef13e70f38cbc7989c0b4d994873b9..8cfc553b059db22a2deb4c86210edb70
 -    protected final Queue<FutureTask<?>> j = new java.util.concurrent.ConcurrentLinkedQueue<FutureTask<?>>(); // Spigot, PAIL: Rename
 +    protected final Queue<FutureTask<?>> j = new com.destroystokyo.paper.utils.CachedSizeConcurrentLinkedQueue<>(); // Spigot, PAIL: Rename // PandaSpigot - Make size() constant-time
      private Thread serverThread;
-     private long ab; // PandaSpigot - Initializer az() is redundant
+     private long ab; // PandaSpigot - The az() initializer is redundant
  

--- a/patches/server/0035-Optimize-Network-Queue.patch
+++ b/patches/server/0035-Optimize-Network-Queue.patch
@@ -45,7 +45,7 @@ index 0000000000000000000000000000000000000000..c8540d16defdc633113b504616794f44
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index b784f8174b94c6fab41ed3262009383a2ffba3cc..26f1e07cefd54afe3df1b8ce8e4d58b26619c8d3 100644
+index 348c63892aef13e70f38cbc7989c0b4d994873b9..8cfc553b059db22a2deb4c86210edb705d41e2ac 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -100,7 +100,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
@@ -55,5 +55,5 @@ index b784f8174b94c6fab41ed3262009383a2ffba3cc..26f1e07cefd54afe3df1b8ce8e4d58b2
 -    protected final Queue<FutureTask<?>> j = new java.util.concurrent.ConcurrentLinkedQueue<FutureTask<?>>(); // Spigot, PAIL: Rename
 +    protected final Queue<FutureTask<?>> j = new com.destroystokyo.paper.utils.CachedSizeConcurrentLinkedQueue<>(); // Spigot, PAIL: Rename // PandaSpigot - Make size() constant-time
      private Thread serverThread;
-     private long ab = az();
+     private long ab; // PandaSpigot - Initializer az() is redundant
  

--- a/patches/server/0036-Backport-PlayerProfile-API.patch
+++ b/patches/server/0036-Backport-PlayerProfile-API.patch
@@ -320,10 +320,10 @@ index 9034e1ad7a013c7288e68322a65798e40d8b851d..86ab9994079c6e18e3aed885db4171d0
      public EntityFishingHook hookedFish;
      public boolean affectsSpawning = true; // PaperSpigot
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 0f893196390e04f8c512f401612c5d455e25bec1..75716099df3c3afc9e5857258ed6d1b271c4b957 100644
+index 8cfc553b059db22a2deb4c86210edb705d41e2ac..ad16adf4dc9775bc7c2553d6a67b4ff08f52cc1d 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1641,6 +1641,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
+@@ -1634,6 +1634,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
          return true;
      }
  

--- a/patches/server/0040-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0040-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -242,7 +242,7 @@ index 09085582a95fc4c61034db70dd543c5e7da8ede7..cd22366c7b066494192e0602da174701
          System.setOut(new PrintStream(new LoggerOutputStream(logger, Level.INFO), true));
          System.setErr(new PrintStream(new LoggerOutputStream(logger, Level.WARN), true));
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 75716099df3c3afc9e5857258ed6d1b271c4b957..aee5ab9daf53a082513ebc14d670395959c6de7e 100644
+index ad16adf4dc9775bc7c2553d6a67b4ff08f52cc1d..56c94d2453cd1ba6d2a531e52776ef5c0ce8bfb4 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -41,7 +41,7 @@ import org.apache.logging.log4j.Logger;
@@ -263,7 +263,7 @@ index 75716099df3c3afc9e5857258ed6d1b271c4b957..aee5ab9daf53a082513ebc14d6703959
      public static int currentTick = 0; // PaperSpigot - Further improve tick loop
      public final Thread primaryThread;
      public java.util.Queue<Runnable> processQueue = new java.util.concurrent.ConcurrentLinkedQueue<Runnable>();
-@@ -160,6 +160,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
+@@ -159,6 +159,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
          this.Y = this.V.createProfileRepository();
          // CraftBukkit start
          this.options = options;
@@ -271,7 +271,7 @@ index 75716099df3c3afc9e5857258ed6d1b271c4b957..aee5ab9daf53a082513ebc14d6703959
          // Try to see if we're actually running in a terminal, disable jline if not
          if (System.console() == null && System.getProperty("jline.terminal") == null) {
              System.setProperty("jline.terminal", "jline.UnsupportedTerminal");
-@@ -181,6 +182,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
+@@ -180,6 +181,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
                  LOGGER.warn((String) null, ex);
              }
          }
@@ -279,7 +279,7 @@ index 75716099df3c3afc9e5857258ed6d1b271c4b957..aee5ab9daf53a082513ebc14d6703959
          Runtime.getRuntime().addShutdownHook(new org.bukkit.craftbukkit.util.ServerShutdownThread(this));
  
          //this.serverThread = primaryThread = new Thread(this, "Server thread"); // Moved from main // PandaSpigot - comment out; we assign above
-@@ -691,7 +693,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
+@@ -684,7 +686,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
              } finally {
                  // CraftBukkit start - Restore terminal to original settings
                  try {
@@ -288,7 +288,7 @@ index 75716099df3c3afc9e5857258ed6d1b271c4b957..aee5ab9daf53a082513ebc14d6703959
                  } catch (Exception ignored) {
                  }
                  // CraftBukkit end
-@@ -1309,7 +1311,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
+@@ -1302,7 +1304,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
      }
  
      public void sendMessage(IChatBaseComponent ichatbasecomponent) {

--- a/patches/server/0047-Only-process-BlockPhysicsEvent-if-a-plugin-has-a-lis.patch
+++ b/patches/server/0047-Only-process-BlockPhysicsEvent-if-a-plugin-has-a-lis.patch
@@ -19,10 +19,10 @@ index c1110242136e8fd98661886920b765bb5367c37d..81fc97dc295677f5c2914e8c9b97a3f4
              org.bukkit.block.Block block = world.getWorld().getBlockAt(blockposition.getX(), blockposition.getY(), blockposition.getZ());
              BlockPhysicsEvent event = new BlockPhysicsEvent(block, block.getTypeId());
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index d71dc092fd9bd33e885b7421421c0ea5cc22efb3..5a3f3f762754374b0635b959c381aeffa682f56e 100644
+index 56c94d2453cd1ba6d2a531e52776ef5c0ce8bfb4..0afe4f68649e3c7cd48eb56f27f5f05eeee52cd1 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -931,6 +931,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
+@@ -924,6 +924,7 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
              // if (i == 0 || this.getAllowNether()) {
                  WorldServer worldserver = this.worlds.get(i);
                  worldserver.hasEntityMoveEvent = io.papermc.paper.event.entity.EntityMoveEvent.getHandlerList().getRegisteredListeners().length > 0; // PandaSpigot
@@ -31,7 +31,7 @@ index d71dc092fd9bd33e885b7421421c0ea5cc22efb3..5a3f3f762754374b0635b959c381aeff
                  this.methodProfiler.a(worldserver.getWorldData().getName());
                  /* Drop global time updates
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 3795d7f097c8051e5e80f6920d1b3fd69531c994..b75d78da71f24a0b02bf709d026389add0556489 100644
+index 42c077870727d1eb40bc9bf5e0a3ca580131331d..589bf95c13e9c78c792498a7b73fd0480f4a503d 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -574,7 +574,7 @@ public abstract class World implements IBlockAccess {

--- a/patches/server/0071-Skip-updating-entity-tracker-if-server-is-empty.patch
+++ b/patches/server/0071-Skip-updating-entity-tracker-if-server-is-empty.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Skip updating entity tracker if server is empty
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 190ee669e532ad26f4bceca4059feb0f81d48459..fb5e2990bb198ba48488757ba011e84a89c75877 100644
+index 0afe4f68649e3c7cd48eb56f27f5f05eeee52cd1..dcb3db06c74f1936c9ec1154ec1b92cd7f323dc5 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -993,7 +993,9 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
+@@ -986,7 +986,9 @@ public abstract class MinecraftServer extends com.hpfxd.pandaspigot.tickloop.Ree
                  }
                  try {
                  // PandaSpigot end


### PR DESCRIPTION
Changes:
- Moved the getMillis() and getNanos() methods to the SystemUtils class (as it is in 1.13+)
- Fix the aL()/ThreadWatchDog method returning/using the wrong variable;
 * To understand more about this bug:
By default, Minecraft has the "nextTick" variable called "ab", with the Modern Tick Loop (which we backported from WindSpigot) it added a redundant variable called "nextTickTime", and the aL() method continued using the old variable "ab", this bug is caused by WindSpigot itself, since in the original pullrequest for NachoSpigot it does not exist because the author deleted the "ab" variable and used the "nextTickTime" variable in the method, in PandaSpigot I did the opposite and removed the nextTickTime and used "ab" since it is unnecessary to add a new variable to do the same thing that "ab" already does