### PR TITLE
Update Paper submodule to point to archive repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "Paper"]
 	path = base/Paper
-	url = https://github.com/PaperMC/Paper.git
+	url = https://github.com/PaperMC/Paper-archive.git
 	branch = ver/1.8.8


### PR DESCRIPTION
Paper will soon move all version branches from 1.8 to 1.21.3 to the 'Paper-archive' repo as part of their hard fork process.

See https://forums.papermc.io/threads/the-future-of-paper-hard-fork.1451/ for details