### PR TITLE
Add additional catch to handle NPE on usercache loading

### DIFF
--- a/patches/server/0106-Add-additional-catch-to-handle-NPE-on-usercache-load.patch
+++ b/patches/server/0106-Add-additional-catch-to-handle-NPE-on-usercache-load.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: uRyanxD <familiarodrigues123ro@gmail.com>
+Date: Fri, 3 Jan 2025 01:16:30 -0300
+Subject: [PATCH] Add additional catch to handle NPE on usercache loading
+
+
+diff --git a/src/main/java/net/minecraft/server/UserCache.java b/src/main/java/net/minecraft/server/UserCache.java
+index d7dee8b3920b1803f751f3fa206fe035764ad6c0..a989de2caee8e1cdea731fcf7dd112a4a6dd840a 100644
+--- a/src/main/java/net/minecraft/server/UserCache.java
++++ b/src/main/java/net/minecraft/server/UserCache.java
+@@ -211,7 +211,7 @@ public class UserCache {
+         } catch (FileNotFoundException filenotfoundexception) {
+             ;
+         // Spigot Start
+-        } catch (com.google.gson.JsonSyntaxException ex) {
++        } catch (com.google.gson.JsonSyntaxException | NullPointerException ex) { // PandaSpigot - Add additional catch to handle NPE on usercache loading
+             JsonList.a.warn( "Usercache.json is corrupted or has bad formatting. Deleting it to prevent further issues." );
+             this.g.delete();
+         // Spigot End


### PR DESCRIPTION
It is common for people to ask for help on discord due to corrupted usercache throwing NPE, now the server will deal with it