### PR TITLE
fix: launcher.mojang.com is not working anymore

### DIFF
--- a/build-logic/src/main/kotlin/paperclip.gradle.kts
+++ b/build-logic/src/main/kotlin/paperclip.gradle.kts
@@ -51,7 +51,7 @@ tasks {
             properties.setProperty("originalHash", vanillaHash.toHex())
             properties.setProperty("patchedHash", patchedHash.toHex())
             properties.setProperty("patch", "pandaspigot.patch")
-            properties.setProperty("sourceUrl", "https://launcher.mojang.com/v1/objects/${vanillaSha1.toHex().toLowerCase()}/server.jar")
+            properties.setProperty("sourceUrl", "https://piston-data.mojang.com/v1/objects/${vanillaSha1.toHex().toLowerCase()}/server.jar")
             properties.setProperty("version", "1.8.8")
 
             logger.info("Writing properties file")


### PR DESCRIPTION
Seems like launcher.mojang.com is not working anymore and causing exception when trying to download server.jar:
```
Downloading vanilla jar...
Failed to download vanilla jar
java.net.UnknownHostException: launcher.mojang.com
	at java.base/sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:567)
	at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:327)
	at java.base/java.net.Socket.connect(Socket.java:751)
	at java.base/sun.security.ssl.SSLSocketImpl.connect(SSLSocketImpl.java:304)
	at java.base/sun.security.ssl.BaseSSLSocketImpl.connect(BaseSSLSocketImpl.java:181)
	at java.base/sun.net.NetworkClient.doConnect(NetworkClient.java:183)
	at java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:531)
	at java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:636)
	at java.base/sun.net.www.protocol.https.HttpsClient.<init>(HttpsClient.java:264)
	at java.base/sun.net.www.protocol.https.HttpsClient.New(HttpsClient.java:377)
	at java.base/sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.getNewHttpClient(AbstractDelegateHttpsURLConnection.java:193)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1252)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:1138)
	at java.base/sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:179)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1690)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1614)
	at java.base/sun.net.www.protocol.https.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java:223)
	at java.base/java.net.URL.openStream(URL.java:1325)
	at com.hpfxd.pandaspigot.paperclip.Paperclip.checkVanillaJar(Paperclip.java:191)
	at com.hpfxd.pandaspigot.paperclip.Paperclip.checkPaperJar(Paperclip.java:122)
	at com.hpfxd.pandaspigot.paperclip.Paperclip.setupEnv(Paperclip.java:95)
	at com.hpfxd.pandaspigot.paperclip.Paperclip.main(Paperclip.java:49)
```
After checking new versions of paper, i've seen an url https://piston-data.mojang.com that seems to be working fine. Replacing it in patch.properties helped and the server.jar downloaded successfully

I'm still not quite sure if it has been removed or its just an outage but you can't even download minecraft launcher from official website rn cuz its trying to download it from https://launcher.mojang.com