### PR TITLE
Accurate pearl Y level tracking 

### DIFF
--- a/patches/server/0107-Accurate-pearl-Y-level-tracking-Configurable.patch
+++ b/patches/server/0107-Accurate-pearl-Y-level-tracking-Configurable.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: ptbnate <playsumer162@gmail.com>
+Date: Mon, 3 Feb 2025 18:43:24 +0500
+Subject: [PATCH] Accurate pearl Y level tracking (Configurable)
+
+
+diff --git a/src/main/java/com/hpfxd/pandaspigot/config/PandaSpigotWorldConfig.java b/src/main/java/com/hpfxd/pandaspigot/config/PandaSpigotWorldConfig.java
+index 360ed37b95fce68941c234615b465090b8ea7308..4db44d9ce50feb9a08b8762f21a6dde8579afbbb 100644
+--- a/src/main/java/com/hpfxd/pandaspigot/config/PandaSpigotWorldConfig.java
++++ b/src/main/java/com/hpfxd/pandaspigot/config/PandaSpigotWorldConfig.java
+@@ -62,4 +62,7 @@ public class PandaSpigotWorldConfig {
+     @Comment("This option controls whether or not there is a chance for arrow crits to deal extra damage.\n" +
+             "By default, this is true (vanilla behaviour)")
+     public boolean randomArrowDamage = true;
++
++    @Comment("Whether the player teleports to the opponent's Y level when their pearl hits the opponent.")
++    public boolean pearlMatchY = false;
+ }
+diff --git a/src/main/java/net/minecraft/server/EntityEnderPearl.java b/src/main/java/net/minecraft/server/EntityEnderPearl.java
+index 319c0bc6f621d54ca36e6e2b210a308122f1e070..4cfa2dc8a379d6386e8444999af0d3c0d33758a3 100644
+--- a/src/main/java/net/minecraft/server/EntityEnderPearl.java
++++ b/src/main/java/net/minecraft/server/EntityEnderPearl.java
+@@ -53,6 +53,12 @@ public class EntityEnderPearl extends EntityProjectile {
+                     location.setPitch(player.getLocation().getPitch());
+                     location.setYaw(player.getLocation().getYaw());
+ 
++                    // PandaSpigot start - Teleport the player to the opponent's Y level when hit.
++                    if (movingobjectposition.entity instanceof EntityPlayer && this.world.pandaSpigotConfig.pearlMatchY) {
++                        location.setY(movingobjectposition.entity.locY);
++                    }
++                    // PandaSpigot end
++
+                     PlayerTeleportEvent teleEvent = new PlayerTeleportEvent(player, player.getLocation(), location, PlayerTeleportEvent.TeleportCause.ENDER_PEARL);
+                     Bukkit.getPluginManager().callEvent(teleEvent);
+ 

--- a/patches/server/0107-Accurate-pearl-Y-level-tracking-Configurable.patch
+++ b/patches/server/0107-Accurate-pearl-Y-level-tracking-Configurable.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: ptbnate <playsumer162@gmail.com>
+From: ptbnate <nasxeaty@gmail.com>
 Date: Mon, 3 Feb 2025 18:43:24 +0500
 Subject: [PATCH] Accurate pearl Y level tracking (Configurable)
 

--- a/patches/server/0108-Fix-entities-going-out-of-sight.patch
+++ b/patches/server/0108-Fix-entities-going-out-of-sight.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: ptbnate <playsumer162@gmail.com>
+From: ptbnate <nasxeaty@gmail.com>
 Date: Mon, 3 Feb 2025 19:29:28 +0500
 Subject: [PATCH] Fix entities going out of sight
 

--- a/patches/server/0108-Fix-entities-going-out-of-sight.patch
+++ b/patches/server/0108-Fix-entities-going-out-of-sight.patch
@@ -1,0 +1,46 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: ptbnate <playsumer162@gmail.com>
+Date: Mon, 3 Feb 2025 19:29:28 +0500
+Subject: [PATCH] Fix entities going out of sight
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
+index 32752dfad24bc7883b1ab52e29834f1aa6fa60c6..8dc930dc17aa235e0147b2a5a3043b049d3e404b 100644
+--- a/src/main/java/net/minecraft/server/EntityLiving.java
++++ b/src/main/java/net/minecraft/server/EntityLiving.java
+@@ -1798,7 +1798,34 @@ public abstract class EntityLiving extends Entity {
+     }
+ 
+     public boolean hasLineOfSight(Entity entity) {
+-        return this.world.rayTrace(new Vec3D(this.locX, this.locY + (double) this.getHeadHeight(), this.locZ), new Vec3D(entity.locX, entity.locY + (double) entity.getHeadHeight(), entity.locZ)) == null;
++        // PandaSpigot start - Fix issue with entities going out of sight
++        Vec3D vec = new Vec3D(this.locX, this.locY + (double) this.getHeadHeight(), this.locZ);
++
++        if (entity instanceof EntityPlayer) {
++            // Head height is 1,5725
++            // Split it into three to get a more accurate line of sight -> 0.52416667
++
++            double parts = entity.getHeadHeight() / 3;
++
++            Vec3D vec3 = new Vec3D(entity.locX, entity.locY, entity.locZ);
++
++            return this.world.rayTrace(
++                    vec,
++                    vec3.add(0.0D, (parts * 3), 0.0D)
++            ) == null || this.world.rayTrace(
++                    vec,
++                    vec3.add(0.0D, (parts * 2), 0.0D)
++            ) == null || this.world.rayTrace(
++                    vec,
++                    vec3.add(0.0D, (parts * 1), 0.0D)
++            ) == null;
++        } else {
++            return this.world.rayTrace(
++                    vec,
++                    new Vec3D(entity.locX, entity.locY + (double) this.getHeadHeight(), entity.locZ)
++            ) == null;
++        }
++        // PandaSpigot end
+     }
+ 
+     public Vec3D ap() {


### PR DESCRIPTION
This feature is highly requested by most PvP based servers. In vanilla mc, when a player throws a pearl at an opponent, they teleport to the pearl's landing position, often leaving them in the air. This feature ensures the player teleports to the opponent’s Y level instead.