### PR TITLE
[skip ci] Small adjustments to the scripts

### DIFF
--- a/panda
+++ b/panda
@@ -66,13 +66,6 @@ case "$1" in
         scripts/build.sh "$basedir" "--jar" || exit 1
     ) || failed=1
     ;;
-    "fj" | "fastjar")
-    (
-        set -e
-        cd "$basedir"
-        ./gradlew build && ./scripts/paperclip.sh "$basedir"
-    ) || failed=1
-    ;;
     "pc" | "paperclip")
     (
         set -e
@@ -179,7 +172,6 @@ case "$1" in
         echo "  * setup               | Remap, decompile, and patch Minecraft. Can be run from anywhere."
         echo "  * p, patch            | Apply all patches to the project without building it. Can be run from anywhere."
         echo "  * j, jar              | Apply all patches and build the project, paperclip.jar will be output. Can be run from anywhere."
-        echo "  * fj, fastjar         | Similar to the "jar" argument, but skips patch application and the setup script."
         echo "  * c, clean            | Removes all generated files, PandaSpigot-API, PandaSpigot-Server, and work."
         echo "  * con, continue       | Shortcut command for running git am --continue, or git rebase --continue."
         echo ""

--- a/panda
+++ b/panda
@@ -66,6 +66,13 @@ case "$1" in
         scripts/build.sh "$basedir" "--jar" || exit 1
     ) || failed=1
     ;;
+    "fj" | "fastjar")
+    (
+        set -e
+        cd "$basedir"
+        ./gradlew build && ./scripts/paperclip.sh "$basedir"
+    ) || failed=1
+    ;;
     "pc" | "paperclip")
     (
         set -e
@@ -172,6 +179,7 @@ case "$1" in
         echo "  * setup               | Remap, decompile, and patch Minecraft. Can be run from anywhere."
         echo "  * p, patch            | Apply all patches to the project without building it. Can be run from anywhere."
         echo "  * j, jar              | Apply all patches and build the project, paperclip.jar will be output. Can be run from anywhere."
+        echo "  * fj, fastjar         | Similar to the "jar" argument, but skips patch application and the setup script."
         echo "  * c, clean            | Removes all generated files, PandaSpigot-API, PandaSpigot-Server, and work."
         echo "  * con, continue       | Shortcut command for running git am --continue, or git rebase --continue."
         echo ""

--- a/panda
+++ b/panda
@@ -63,7 +63,12 @@ case "$1" in
     (
         set -e
         cd "$basedir"
-        scripts/build.sh "$basedir" "--jar" || exit 1
+
+        if [[ "$3" == "fast" ]]; then
+            scripts/build.sh "$basedir" "--jar" "--fast" || exit 1
+        else
+            scripts/build.sh "$basedir" "--jar" || exit 1
+        fi
     ) || failed=1
     ;;
     "pc" | "paperclip")

--- a/panda
+++ b/panda
@@ -63,12 +63,7 @@ case "$1" in
     (
         set -e
         cd "$basedir"
-
-        if [[ "$3" == "fast" ]]; then
-            scripts/build.sh "$basedir" "--jar" "--fast" || exit 1
-        else
-            scripts/build.sh "$basedir" "--jar" || exit 1
-        fi
+        scripts/build.sh "$basedir" "--jar" || exit 1
     ) || failed=1
     ;;
     "pc" | "paperclip")

--- a/scripts/applyPatches.sh
+++ b/scripts/applyPatches.sh
@@ -4,7 +4,7 @@
 PS1="$"
 basedir="$(cd "$1" && pwd -P)"
 workdir="$basedir/base"
-minecraftversion=$(cat "$workdir/Paper/BuildData/info.json"  | grep minecraftVersion | cut -d '"' -f 4)
+minecraftversion=$(cat "$workdir/Paper/BuildData/info.json" | grep minecraftVersion | cut -d '"' -f 4)
 gitcmd="git -c commit.gpgsign=false"
 applycmd="$gitcmd am --3way --ignore-whitespace"
 # Windows detection to workaround ARG_MAX limitation
@@ -22,7 +22,7 @@ function applyPatch {
     $gitcmd branch -f upstream "$branch" >/dev/null
 
     cd "$basedir"
-    if [ ! -d  "$basedir/$target" ]; then
+    if [ ! -d "$basedir/$target" ]; then
         $gitcmd clone "$what" "$target"
     fi
     cd "$basedir/$target"
@@ -105,9 +105,7 @@ if [ "$2" == "--setup" ] || [ "$2" == "--jar" ]; then
     echo "Importing MC Dev"
 
     ./scripts/importmcdev.sh "$basedir" || exit 1
-fi
 
-if [ "$2" != "--setup" ]; then
     if [ ! -d "base/Paper/PaperSpigot-Server" ]; then
         echo "Upstream directory does not exist. Did you forget to run 'panda setup'?"
         exit 1

--- a/scripts/applyPatches.sh
+++ b/scripts/applyPatches.sh
@@ -105,20 +105,20 @@ if [ "$2" == "--setup" ] || [ "$2" == "--jar" ]; then
     echo "Importing MC Dev"
 
     ./scripts/importmcdev.sh "$basedir" || exit 1
+fi
 
-    if [ ! -d "base/Paper/PaperSpigot-Server" ]; then
-        echo "Upstream directory does not exist. Did you forget to run 'panda setup'?"
+if [ ! -d "base/Paper/PaperSpigot-Server" ]; then
+    echo "Upstream directory does not exist. Did you forget to run 'panda setup'?"
+    exit 1
+else
+    # Apply PandaSpigot
+    (
+        applyPatch "base/Paper/PaperSpigot-API" PandaSpigot-API HEAD patches/api &&
+        applyPatch "base/Paper/PaperSpigot-Server" PandaSpigot-Server HEAD patches/server
+        cd "$basedir"
+    ) || (
+        echo "Failed to apply PandaSpigot Patches"
         exit 1
-    else
-        # Apply PandaSpigot
-        (
-            applyPatch "base/Paper/PaperSpigot-API" PandaSpigot-API HEAD patches/api &&
-            applyPatch "base/Paper/PaperSpigot-Server" PandaSpigot-Server HEAD patches/server
-            cd "$basedir"
-        ) || (
-            echo "Failed to apply PandaSpigot Patches"
-            exit 1
-        ) || exit 1
-    fi
+    ) || exit 1
 fi
 ) || exit 1

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,7 +6,7 @@ basedir="$(cd "$1" && pwd -P)"
 gitcmd="git -c commit.gpgsign=false"
 
 ($gitcmd submodule update --init --recursive && ./scripts/remap.sh "$basedir" && ./scripts/decompile.sh "$basedir" && ./scripts/init.sh "$basedir" && ./scripts/applyPatches.sh "$basedir" "$2") || (
-    echo "Failed to start PandaSpigot"
+    echo "PandaSpigot setup failed"
     exit 1
 ) || exit 1
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,10 +5,14 @@ set -e
 basedir="$(cd "$1" && pwd -P)"
 gitcmd="git -c commit.gpgsign=false"
 
-($gitcmd submodule update --init --recursive && ./scripts/remap.sh "$basedir" && ./scripts/decompile.sh "$basedir" && ./scripts/init.sh "$basedir" && ./scripts/applyPatches.sh "$basedir" "$2") || (
-    echo "PandaSpigot setup failed"
-    exit 1
-) || exit 1
+if [ "$2" == "--jar" ] && [ "$3" == "--fast" ]; then
+    echo "Skipping PandaSpigot setup because --jar and --fast are specified."
+else
+    ($gitcmd submodule update --init --recursive && ./scripts/remap.sh "$basedir" && ./scripts/decompile.sh "$basedir" && ./scripts/init.sh "$basedir" && ./scripts/applyPatches.sh "$basedir" "$2") || (
+        echo "PandaSpigot setup failed"
+        exit 1
+    ) || exit 1
+fi
 
 if [ "$2" == "--jar" ]; then
     ./gradlew build && ./scripts/paperclip.sh "$basedir"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,14 +5,10 @@ set -e
 basedir="$(cd "$1" && pwd -P)"
 gitcmd="git -c commit.gpgsign=false"
 
-if [ "$2" == "--jar" ] && [ "$3" == "--fast" ]; then
-    echo "Skipping PandaSpigot setup because --jar and --fast are specified."
-else
-    ($gitcmd submodule update --init --recursive && ./scripts/remap.sh "$basedir" && ./scripts/decompile.sh "$basedir" && ./scripts/init.sh "$basedir" && ./scripts/applyPatches.sh "$basedir" "$2") || (
-        echo "PandaSpigot setup failed"
-        exit 1
-    ) || exit 1
-fi
+($gitcmd submodule update --init --recursive && ./scripts/remap.sh "$basedir" && ./scripts/decompile.sh "$basedir" && ./scripts/init.sh "$basedir" && ./scripts/applyPatches.sh "$basedir" "$2") || (
+    echo "PandaSpigot setup failed"
+    exit 1
+) || exit 1
 
 if [ "$2" == "--jar" ]; then
     ./gradlew build && ./scripts/paperclip.sh "$basedir"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,15 +5,10 @@ set -e
 basedir="$(cd "$1" && pwd -P)"
 gitcmd="git -c commit.gpgsign=false"
 
-$gitcmd submodule update --init --recursive
-cd "$basedir"
-
-if [ "$2" == "--setup" ] || [ "$2" == "--jar" ]; then
-    ./scripts/remap.sh "$basedir"
-    ./scripts/decompile.sh "$basedir"
-    ./scripts/init.sh "$basedir"
-fi
-./scripts/applyPatches.sh "$basedir" "$2"
+($gitcmd submodule update --init --recursive && ./scripts/remap.sh "$basedir" && ./scripts/decompile.sh "$basedir" && ./scripts/init.sh "$basedir" && ./scripts/applyPatches.sh "$basedir" "$2") || (
+    echo "Failed to start PandaSpigot"
+    exit 1
+) || exit 1
 
 if [ "$2" == "--jar" ]; then
     ./gradlew build && ./scripts/paperclip.sh "$basedir"


### PR DESCRIPTION
- Revert my change that made Panda patches only apply when running ./panda patch, now they will be applied again when using ./panda setup
- Small improvements in build.sh:
Added a message if any script fails
Removed argument checking (It used to be useful because ./panda patch runs this script, a few commits ago I changed it to run applyPatches.sh directly)
Removed cd "$basedir", the "panda" script already does this