### PR TITLE
[skip ci] Try creating the directory only once

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,7 +6,7 @@ basedir="$(cd "$1" && pwd -P)"
 gitcmd="git -c commit.gpgsign=false"
 
 ($gitcmd submodule update --init --recursive && ./scripts/remap.sh "$basedir" && ./scripts/decompile.sh "$basedir" && ./scripts/init.sh "$basedir" && ./scripts/applyPatches.sh "$basedir" "$2") || (
-    echo "PandaSpigot setup failed"
+    echo "PandaSpigot setup stage failed"
     exit 1
 ) || exit 1
 

--- a/scripts/importmcdev.sh
+++ b/scripts/importmcdev.sh
@@ -12,14 +12,12 @@ workdir="$basedir/base"
 minecraftversion=$(cat "$workdir/Paper/BuildData/info.json" | grep minecraftVersion | cut -d '"' -f 4)
 decompiledir="$workdir/mc-dev/spigot"
 
-find "$decompiledir/$nms" -type f -name "*.java" | while read file; do
-    filename=$(basename "$file")
+while IFS= read -r -d '' file; do
+    filename="${file##*/}"
     target="$workdir/Paper/PaperSpigot-Server/src/main/java/$nms/$filename"
 
-    if [[ ! -f "$target" ]]; then
-        cp "$file" "$target"
-    fi
-done
+    [[ -f "$target" ]] || cp "$file" "$target"
+done < <(find "$decompiledir/$nms" -type f -name "*.java" -print0)
 
 cp -rt "$workdir/Paper/PaperSpigot-Server/src/main/resources" "$decompiledir/assets" "$decompiledir/yggdrasil_session_pubkey.der"
 

--- a/scripts/importmcdev.sh
+++ b/scripts/importmcdev.sh
@@ -12,12 +12,12 @@ workdir="$basedir/base"
 minecraftversion=$(cat "$workdir/Paper/BuildData/info.json" | grep minecraftVersion | cut -d '"' -f 4)
 decompiledir="$workdir/mc-dev/spigot"
 
-while IFS= read -r -d '' file; do
-    filename="${file##*/}"
+find "$decompiledir/$nms" -type f -name "*.java" -print0 | while IFS= read -r -d '' file; do
+    filename="$(basename "$file")"
     target="$workdir/Paper/PaperSpigot-Server/src/main/java/$nms/$filename"
-
-    [[ -f "$target" ]] || cp "$file" "$target"
-done < <(find "$decompiledir/$nms" -type f -name "*.java" -print0)
+    
+    [[ ! -f "$target" ]] && cp "$file" "$target"
+done
 
 cp -rt "$workdir/Paper/PaperSpigot-Server/src/main/resources" "$decompiledir/assets" "$decompiledir/yggdrasil_session_pubkey.der"
 

--- a/scripts/importmcdev.sh
+++ b/scripts/importmcdev.sh
@@ -12,11 +12,11 @@ workdir="$basedir/base"
 minecraftversion=$(cat "$workdir/Paper/BuildData/info.json" | grep minecraftVersion | cut -d '"' -f 4)
 decompiledir="$workdir/mc-dev/spigot"
 
-find "$decompiledir/$nms" -type f -name "*.java" | while read -r file; do
+find "$decompiledir/$nms" -type f -name "*.java" | while read file; do
     filename="$(basename "$file")"
     target="$workdir/Paper/PaperSpigot-Server/src/main/java/$nms/$filename"
 
-    if [ ! -f "$target" ]; then
+    if [[ ! -f "$target" ]]; then
         cp "$file" "$target"
     fi
 done

--- a/scripts/importmcdev.sh
+++ b/scripts/importmcdev.sh
@@ -15,8 +15,10 @@ decompiledir="$workdir/mc-dev/spigot"
 find "$decompiledir/$nms" -type f -name "*.java" -print0 | while IFS= read -r -d '' file; do
     filename="$(basename "$file")"
     target="$workdir/Paper/PaperSpigot-Server/src/main/java/$nms/$filename"
-    
-    if [[ ! -f "$target" ]]; then
+
+    if [ ! -f "$target" ]; then
+        #mkdir -p "$(dirname "$dest_file")"
+        #echo "Copiando $nms/$rel_path..."
         cp "$file" "$target"
     fi
 done

--- a/scripts/importmcdev.sh
+++ b/scripts/importmcdev.sh
@@ -16,7 +16,9 @@ find "$decompiledir/$nms" -type f -name "*.java" -print0 | while IFS= read -r -d
     filename="$(basename "$file")"
     target="$workdir/Paper/PaperSpigot-Server/src/main/java/$nms/$filename"
     
-    [[ ! -f "$target" ]] && cp "$file" "$target"
+    if [[ ! -f "$target" ]]; then
+        cp "$file" "$target"
+    fi
 done
 
 cp -rt "$workdir/Paper/PaperSpigot-Server/src/main/resources" "$decompiledir/assets" "$decompiledir/yggdrasil_session_pubkey.der"

--- a/scripts/importmcdev.sh
+++ b/scripts/importmcdev.sh
@@ -17,8 +17,6 @@ find "$decompiledir/$nms" -type f -name "*.java" -print0 | while IFS= read -r -d
     target="$workdir/Paper/PaperSpigot-Server/src/main/java/$nms/$filename"
 
     if [ ! -f "$target" ]; then
-        #mkdir -p "$(dirname "$dest_file")"
-        #echo "Copiando $nms/$rel_path..."
         cp "$file" "$target"
     fi
 done

--- a/scripts/importmcdev.sh
+++ b/scripts/importmcdev.sh
@@ -12,7 +12,7 @@ workdir="$basedir/base"
 minecraftversion=$(cat "$workdir/Paper/BuildData/info.json" | grep minecraftVersion | cut -d '"' -f 4)
 decompiledir="$workdir/mc-dev/spigot"
 
-find "$decompiledir/$nms" -type f -name "*.java" -print0 | while IFS= read -r -d '' file; do
+find "$decompiledir/$nms" -type f -name "*.java" | while read -r file; do
     filename="$(basename "$file")"
     target="$workdir/Paper/PaperSpigot-Server/src/main/java/$nms/$filename"
 

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -33,14 +33,14 @@ echo "Applying CraftBukkit patches to NMS..."
 cd "$workdir/Paper/CraftBukkit"
 $gitcmd checkout -B patched HEAD >/dev/null 2>&1
 rm -rf "$cb"
+mkdir -p "$cb"
 # create baseline NMS import so we can see diff of what CB changed
 while IFS= read -r -d '' file
 do
     patchFile="$file"
-    file="$(echo "$file" | cut -d "/" -f2- | cut -d. -f1).java"
+    file="$(echo "$file" | cut -d. -f1).java"
     mkdir -p "$(dirname $cb/"$file")"
-    cp "$nms/$file" "$cb/$file"
-done <   <(find nms-patches -type f -print0)
+done < <(find nms-patches -type f -print0)
 $gitcmd add --force src
 $gitcmd commit -q -m "Minecraft $ $(date)" --author="Vanilla <auto@mated.null>"
 
@@ -48,16 +48,15 @@ $gitcmd commit -q -m "Minecraft $ $(date)" --author="Vanilla <auto@mated.null>"
 while IFS= read -r -d '' file
 do
     patchFile="$file"
-    file="$(echo "$file" | cut -d "/" -f2- | cut -d. -f1).java"
+    file="$(echo "$file" | cut -d. -f1).java"
 
     echo "Patching $file < $patchFile"
     set +e
     strip_cr "$nms/$file" > /dev/null
     set -e
 
-    "$patch" -s -d src/main/java -p 1 < "$patchFile"
-done <   <(find nms-patches -type f -print0)
-
+    "$patch" -s -d src/main/java/ "net/minecraft/server/$file" < "$patchFile"
+done < <(find nms-patches -type f -print0)
 
 $gitcmd add --force src
 $gitcmd commit -q -m "CraftBukkit $ $(date)" --author="CraftBukkit <auto@mated.null>"

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -39,7 +39,7 @@ while IFS= read -r -d '' file
 do
     patchFile="$file"
     file="$(echo "$file" | cut -d. -f1).java"
-    mkdir -p "$(dirname $cb/"$file")"
+    cp "$nms/$file" "$cb/$file"
 done < <(find nms-patches -type f -print0)
 $gitcmd add --force src
 $gitcmd commit -q -m "Minecraft $ $(date)" --author="Vanilla <auto@mated.null>"

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -48,7 +48,7 @@ $gitcmd commit -q -m "Minecraft $ $(date)" --author="Vanilla <auto@mated.null>"
 while IFS= read -r -d '' file
 do
     patchFile="$file"
-    file="$(echo "$file" | cut -d. -f1).java"
+    file="$(echo "$file" | cut -d "/" -f2- | cut -d. -f1).java"
 
     echo "Patching $file < $patchFile"
     set +e

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -38,7 +38,7 @@ mkdir -p "$cb"
 while IFS= read -r -d '' file
 do
     patchFile="$file"
-    file="$(echo "$file" | cut -d "/" -f2- |  cut -d. -f1).java"
+    file="$(echo "$file" | cut -d "/" -f2- | cut -d. -f1).java"
     cp "$nms/$file" "$cb/$file"
 done < <(find nms-patches -type f -print0)
 $gitcmd add --force src

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -33,14 +33,12 @@ echo "Applying CraftBukkit patches to NMS..."
 cd "$workdir/Paper/CraftBukkit"
 $gitcmd checkout -B patched HEAD >/dev/null 2>&1
 rm -rf "$cb"
-# mkdir -p "$cb"
+mkdir -p "$cb"
 # create baseline NMS import so we can see diff of what CB changed
 while IFS= read -r -d '' file
 do
     patchFile="$file"
     file="$(echo "$file" | cut -d "/" -f2- | cut -d. -f1).java"
-    echo "Diretório a ser criado: $(dirname $cb/"$file")"
-    mkdir -p "$(dirname $cb/"$file")"
     cp "$nms/$file" "$cb/$file"
 done < <(find nms-patches -type f -print0)
 $gitcmd add --force src

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -38,7 +38,7 @@ mkdir -p "$cb"
 while IFS= read -r -d '' file
 do
     patchFile="$file"
-    file="$(echo "$file" | cut -d. -f1).java"
+    file="$(echo "$file" | cut -d "/" -f2- |  cut -d. -f1).java"
     cp "$nms/$file" "$cb/$file"
 done < <(find nms-patches -type f -print0)
 $gitcmd add --force src

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -55,7 +55,7 @@ do
     strip_cr "$nms/$file" > /dev/null
     set -e
 
-    "$patch" -s -d src/main/java/ "net/minecraft/server/$file" < "$patchFile"
+    "$patch" -s -d src/main/java -p 1 < "$patchFile"
 done < <(find nms-patches -type f -print0)
 
 $gitcmd add --force src

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -33,12 +33,14 @@ echo "Applying CraftBukkit patches to NMS..."
 cd "$workdir/Paper/CraftBukkit"
 $gitcmd checkout -B patched HEAD >/dev/null 2>&1
 rm -rf "$cb"
-mkdir -p "$cb"
+# mkdir -p "$cb"
 # create baseline NMS import so we can see diff of what CB changed
 while IFS= read -r -d '' file
 do
     patchFile="$file"
     file="$(echo "$file" | cut -d "/" -f2- | cut -d. -f1).java"
+    echo "Diretório a ser criado: $(dirname $cb/"$file")"
+    mkdir -p "$(dirname $cb/"$file")"
     cp "$nms/$file" "$cb/$file"
 done < <(find nms-patches -type f -print0)
 $gitcmd add --force src


### PR DESCRIPTION
This pull request simply reverts a change from the "Update scripts for NMS repackaging" commit made in Paper 1.16, from which we inherited the scripts. This change makes sense in the context of repackaged packages, since there are multiple subpackages within nms-patches, but for us it doesn't, since the script just tries to create the "src/main/java/net/minecraft/server" directory multiple times, and some small changes.