### PR TITLE
Fix #278: Taking damage when falling into web from a height >=24 blocks

### DIFF
--- a/patches/server/0112-Fix-collision-detection-of-entities-with-blocks.patch
+++ b/patches/server/0112-Fix-collision-detection-of-entities-with-blocks.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: uRyanxD <familiarodrigues123ro@gmail.com>
 Date: Sat, 7 Jun 2025 19:53:49 -0300
-Subject: [PATCH] Fix collision detection with blocks
+Subject: [PATCH] Fix collision detection of entities with blocks
 
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java

--- a/patches/server/0112-Fix-collision-detection-of-entities-with-blocks.patch
+++ b/patches/server/0112-Fix-collision-detection-of-entities-with-blocks.patch
@@ -5,14 +5,14 @@ Subject: [PATCH] Fix collision detection of entities with blocks
 
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index b8f4a69a1cac37722077f0510c72b087255c892c..47e97735655f1ad4f67b88fee2df6e8733e5aafe 100644
+index b8f4a69a1cac37722077f0510c72b087255c892c..9d8bb72b469163db7def78f623d18dc4056b1f6b 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -451,6 +451,8 @@ public abstract class Entity implements ICommandListener {
              this.a(this.getBoundingBox().c(d0, d1, d2));
              this.recalcPosition();
          } else {
-+            // PandaSpigot start - Fix collision detection with blocks, moved back to below
++            // PandaSpigot start - Fix collision detection of entities with blocks, moved back to below
 +            /*
              // CraftBukkit start - Don't do anything if we aren't moving
              // We need to do this regardless of whether or not we are moving thanks to portals
@@ -31,7 +31,7 @@ index b8f4a69a1cac37722077f0510c72b087255c892c..47e97735655f1ad4f67b88fee2df6e87
  
              // CraftBukkit start - Move to the top of the method
 -            /*
-+            // PandaSpigot start - Fix collision detection with blocks
++            // PandaSpigot start - Fix collision detection of entities with blocks
              try {
                  this.checkBlockCollisions();
              } catch (Throwable throwable) {

--- a/patches/server/0112-Fix-collision-detection-with-blocks.patch
+++ b/patches/server/0112-Fix-collision-detection-with-blocks.patch
@@ -1,0 +1,46 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: uRyanxD <familiarodrigues123ro@gmail.com>
+Date: Sat, 7 Jun 2025 19:53:49 -0300
+Subject: [PATCH] Fix collision detection with blocks
+
+
+diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
+index b8f4a69a1cac37722077f0510c72b087255c892c..47e97735655f1ad4f67b88fee2df6e8733e5aafe 100644
+--- a/src/main/java/net/minecraft/server/Entity.java
++++ b/src/main/java/net/minecraft/server/Entity.java
+@@ -451,6 +451,8 @@ public abstract class Entity implements ICommandListener {
+             this.a(this.getBoundingBox().c(d0, d1, d2));
+             this.recalcPosition();
+         } else {
++            // PandaSpigot start - Fix collision detection with blocks, moved back to below
++            /*
+             // CraftBukkit start - Don't do anything if we aren't moving
+             // We need to do this regardless of whether or not we are moving thanks to portals
+             try {
+@@ -466,6 +468,8 @@ public abstract class Entity implements ICommandListener {
+             if (d0 == 0 && d1 == 0 && d2 == 0 && this.vehicle == null && this.passenger == null) {
+                 return;
+             }
++            */
++            // PandaSpigot end
+             // CraftBukkit end
+             this.world.methodProfiler.a("move");
+             double d3 = this.locX;
+@@ -753,7 +757,7 @@ public abstract class Entity implements ICommandListener {
+             }
+ 
+             // CraftBukkit start - Move to the top of the method
+-            /*
++            // PandaSpigot start - Fix collision detection with blocks
+             try {
+                 this.checkBlockCollisions();
+             } catch (Throwable throwable) {
+@@ -763,7 +767,7 @@ public abstract class Entity implements ICommandListener {
+                 this.appendEntityCrashDetails(crashreportsystemdetails);
+                 throw new ReportedException(crashreport);
+             }
+-            */
++            // PandaSpigot end
+             // CraftBukkit end
+ 
+             boolean flag2 = this.U();


### PR DESCRIPTION
Supersedes #322

Technically, what we fixed here is the collision detection of entities with blocks

Explanation:
the server sets the fallDistance to 0 when it detects that the player has collided with the web, so the player does not take damage, however, CB during the 1.5.1 era added an optimization to avoid calling the movement logic if the entity was not actually moving, but this caused problems with portals, which led CB to move the collision detection above the check, which caused the current problem. I reverted this to vanilla logic, which fixes the problem, about the optimization: It should not have any negative performance impact, since in the original commit it is made clear, that the method is almost never called without the entities actually moving.