### PR TITLE
Native Kyori Adventure API

### DIFF
--- a/patches/api/0027-Adventure-API.patch
+++ b/patches/api/0027-Adventure-API.patch
@@ -853,7 +853,7 @@ index aad03549523391d22e574778250f8169bbac33f6..de569c5eaeeb7de954017b7b4e80f4a8
      /**
       * Gets how much EXP the Player should have at respawn.
 diff --git a/src/main/java/org/bukkit/event/inventory/InventoryType.java b/src/main/java/org/bukkit/event/inventory/InventoryType.java
-index c36e0467281fef62c8362640df1b9e4990562d47..043ac88d080efdc475decd665ef990ce9c574b68 100644
+index c36e0467281fef62c8362640df1b9e4990562d47..db080e2907b61dbd407e10351a751ac0fd5813a1 100644
 --- a/src/main/java/org/bukkit/event/inventory/InventoryType.java
 +++ b/src/main/java/org/bukkit/event/inventory/InventoryType.java
 @@ -73,10 +73,12 @@ public enum InventoryType {
@@ -865,7 +865,7 @@ index c36e0467281fef62c8362640df1b9e4990562d47..043ac88d080efdc475decd665ef990ce
      private InventoryType(int defaultSize, String defaultTitle) {
          size = defaultSize;
          title = defaultTitle;
-+        adventure$title = net.kyori.adventure.text.Component.text(defaultTitle);
++        adventure$title = net.kyori.adventure.text.Component.text(defaultTitle); // PandaSpigot - Adventure
      }
  
      public int getDefaultSize() {

--- a/patches/api/0027-Adventure-API.patch
+++ b/patches/api/0027-Adventure-API.patch
@@ -1189,7 +1189,7 @@ index 3efd15972e79afebce3d30a24b7dabdf8b963d7c..53ff5b655b981ae6e8d4702af05166e1
      public HandlerList getHandlers() {
          return handlers;
 diff --git a/src/main/java/org/bukkit/event/player/PlayerLoginEvent.java b/src/main/java/org/bukkit/event/player/PlayerLoginEvent.java
-index 4bc024ffd3f94c161dd9f64ad5c6201c495e08fa..1ecabb0c6c1c306324230c7ac61be5b042b35476 100644
+index 4bc024ffd3f94c161dd9f64ad5c6201c495e08fa..b1e50d838d5580ff966d4a1db55b48e9b4546791 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerLoginEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerLoginEvent.java
 @@ -13,7 +13,7 @@ public class PlayerLoginEvent extends PlayerEvent {
@@ -1206,7 +1206,7 @@ index 4bc024ffd3f94c161dd9f64ad5c6201c495e08fa..1ecabb0c6c1c306324230c7ac61be5b0
          this(player, hostname, address, realAddress); // Spigot
          this.result = result;
 +     // PandaSpigot start - Adventure
-+        this.message = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(message); // PandaSpigot - Adventure
++        this.message = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(message);
 +    }
 +
 +    /**

--- a/patches/api/0027-Adventure-API.patch
+++ b/patches/api/0027-Adventure-API.patch
@@ -1,0 +1,1902 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MasterDash5 <constant4337@molecularmail.com>
+Date: Sun, 7 Sep 2025 13:58:36 -0600
+Subject: [PATCH] Adventure API
+
+
+diff --git a/build.gradle.kts b/build.gradle.kts
+index 462d7e12d9f38d32e4aa0c9e222d390ee49ebb39..5b438e8867a7a41c955700eae992ae08890f7757 100644
+--- a/build.gradle.kts
++++ b/build.gradle.kts
+@@ -8,6 +8,8 @@ java {
+     withJavadocJar()
+ }
+ 
++val adventureVersion = "4.24.0" // PandaSpigot - Adventure
++
+ dependencies {
+     api("commons-lang:commons-lang:2.6")
+     api("org.avaje:ebean:2.8.1")
+@@ -16,6 +18,13 @@ dependencies {
+     }
+     api("org.yaml:snakeyaml:1.15")
+     api("net.md-5:bungeecord-chat:1.8-SNAPSHOT")
++    // PandaSpigot start - Adventure
++    api("net.kyori:adventure-api:$adventureVersion")
++    api("net.kyori:adventure-text-minimessage:$adventureVersion")
++    api("net.kyori:adventure-text-serializer-legacy:$adventureVersion")
++    api("net.kyori:adventure-text-serializer-gson:$adventureVersion")
++    api("net.kyori:adventure-text-serializer-plain:$adventureVersion")
++    // PandaSpigot end
+     compileOnlyApi("net.sf.trove4j:trove4j:3.0.3") // provided by server
+ 
+     // bundled with Minecraft, should be kept in sync
+@@ -61,6 +70,7 @@ tasks {
+                 "https://guava.dev/releases/17.0/api/docs/",
+                 "https://javadoc.io/doc/org.yaml/snakeyaml/1.15/",
+                 "https://javadoc.io/doc/net.md-5/bungeecord-chat/1.16-R0.4/",
++                "https://javadoc.io/doc/net.kyori/adventure-api/$adventureVersion", // PandaSpigot - Adventure
+             )
+         }
+     }
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index 4ae094a9d190e23efcebd866a8ecb11ebf9167e6..2ae8b301052020afc17c15435d8022c55cce9675 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -329,6 +329,42 @@ public final class Bukkit {
+     }
+     // Paper end
+ 
++    // PandaSpigot start - Adventure
++    /**
++     * Sends a message with the MiniMessage format to the server.
++     * <p>
++     * See <a href="https://docs.advntr.dev/minimessage/">MiniMessage docs</a>
++     * for more information on the format.
++     *
++     * @param message MiniMessage content
++     */
++    public static void sendRichMessage(String message) {
++        server.sendMessage(net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().deserialize(message, server));
++    }
++
++    /**
++     * Sends a message with the MiniMessage format to the server.
++     * <p>
++     * See <a href="https://docs.advntr.dev/minimessage/">MiniMessage docs</a> and <a href="https://docs.advntr.dev/minimessage/dynamic-replacements">MiniMessage Placeholders docs</a>
++     * for more information on the format.
++     *
++     * @param message MiniMessage content
++     * @param resolvers resolvers to use
++     */
++    public static void sendRichMessage(String message, net.kyori.adventure.text.minimessage.tag.resolver.TagResolver... resolvers) {
++        server.sendMessage(net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().deserialize(message, server, resolvers));
++    }
++
++    /**
++     * Sends a plain message to the server.
++     *
++     * @param message plain message
++     */
++    public static void sendPlainMessage(String message) {
++        server.sendMessage(net.kyori.adventure.text.Component.text(message));
++    }
++    // PandaSpigot end
++
+     /**
+      * Gets the name of the update folder. The update folder is used to safely
+      * update plugins at the right moment on a plugin load.
+@@ -975,6 +1011,39 @@ public final class Bukkit {
+         return server.createInventory(owner, size, title);
+     }
+ 
++    // PandaSpigot start - Adventure
++    /**
++     * Creates an empty inventory with the specified type and title. If the type
++     * is {@link InventoryType#CHEST}, the new inventory has a size of 27;
++     * otherwise the new inventory has the normal size for its type.<br>
++     * It should be noted that some inventory types do not support titles and
++     * may not render with said titles on the Minecraft client.
++     *
++     * @param owner The holder of the inventory; can be null if there's no holder.
++     * @param type The type of inventory to create.
++     * @param title The title of the inventory, to be displayed when it is viewed.
++     * @return The new inventory.
++     */
++    public static Inventory createInventory(InventoryHolder owner, InventoryType type, net.kyori.adventure.text.Component title) {
++        return server.createInventory(owner, type, title);
++    }
++
++    /**
++     * Creates an empty inventory of type {@link InventoryType#CHEST} with the
++     * specified size and title.
++     *
++     * @param owner the holder of the inventory, or null to indicate no holder
++     * @param size a multiple of 9 as the size of inventory to create
++     * @param title the title of the inventory, displayed when inventory is
++     *     viewed
++     * @return a new inventory
++     * @throws IllegalArgumentException if the size is not a multiple of 9
++     */
++    public static Inventory createInventory(InventoryHolder owner, int size, net.kyori.adventure.text.Component title) throws IllegalArgumentException {
++        return server.createInventory(owner, size, title);
++    }
++    // PandaSpigot end
++
+     /**
+      * Gets user-specified limit for number of monsters that can spawn in a
+      * chunk.
+@@ -1049,6 +1118,26 @@ public final class Bukkit {
+         return server.getShutdownMessage();
+     }
+ 
++    // PandaSpigot start - Adventure
++    /**
++     * Gets the message that is displayed on the server list.
++     *
++     * @return the servers MOTD
++     */
++    public static net.kyori.adventure.text.Component motd() {
++        return server.motd();
++    }
++
++    /**
++     * Gets the default message that is displayed when the server is stopped.
++     *
++     * @return the shutdown message
++     */
++    public static net.kyori.adventure.text.Component shutdownMessage() {
++        return server.shutdownMessage();
++    }
++    // PandaSpigot end
++
+     /**
+      * Gets the current warning state for the server.
+      *
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index 1ad82f5eddb477d2d9a753c1d2540ccff3d4f392..51849294e3618b94aec5c81c0438d95e00e3a33a 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -47,7 +47,7 @@ import org.bukkit.inventory.meta.ItemMeta;
+ /**
+  * Represents a server implementation.
+  */
+-public interface Server extends PluginMessageRecipient {
++public interface Server extends PluginMessageRecipient, net.kyori.adventure.audience.ForwardingAudience { // PandaSpigot - Adventure
+ 
+     /**
+      * Used for all administrative messages, such as an operator using a
+@@ -254,6 +254,42 @@ public interface Server extends PluginMessageRecipient {
+     public void broadcast(net.md_5.bungee.api.chat.BaseComponent... components);
+     // Paper end
+ 
++    // PandaSpigot start - Adventure
++    /**
++     * Sends a message with the MiniMessage format to the server.
++     * <p>
++     * See <a href="https://docs.advntr.dev/minimessage/">MiniMessage docs</a>
++     * for more information on the format.
++     *
++     * @param message MiniMessage content
++     */
++    default void sendRichMessage(String message) {
++        this.sendMessage(net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().deserialize(message, this));
++    }
++
++    /**
++     * Sends a message with the MiniMessage format to the server.
++     * <p>
++     * See <a href="https://docs.advntr.dev/minimessage/">MiniMessage docs</a> and <a href="https://docs.advntr.dev/minimessage/dynamic-replacements">MiniMessage Placeholders docs</a>
++     * for more information on the format.
++     *
++     * @param message MiniMessage content
++     * @param resolvers resolvers to use
++     */
++    default void sendRichMessage(String message, net.kyori.adventure.text.minimessage.tag.resolver.TagResolver... resolvers) {
++        this.sendMessage(net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().deserialize(message, this, resolvers));
++    }
++
++    /**
++     * Sends a plain message to the server.
++     *
++     * @param message plain message
++     */
++    default void sendPlainMessage(String message) {
++        this.sendMessage(net.kyori.adventure.text.Component.text(message));
++    }
++    // PandaSpigot end
++
+     /**
+      * Gets the name of the update folder. The update folder is used to safely
+      * update plugins at the right moment on a plugin load.
+@@ -782,6 +818,39 @@ public interface Server extends PluginMessageRecipient {
+      */
+     Inventory createInventory(InventoryHolder owner, int size, String title) throws IllegalArgumentException;
+ 
++    // PandaSpigot start - Adventure
++    /**
++     * Creates an empty inventory with the specified type and title. If the type
++     * is {@link InventoryType#CHEST}, the new inventory has a size of 27;
++     * otherwise the new inventory has the normal size for its type.<br>
++     * It should be noted that some inventory types do not support titles and
++     * may not render with said titles on the Minecraft client.
++     *
++     * @param owner The holder of the inventory; can be null if there's no holder.
++     * @param type The type of inventory to create.
++     * @param title The title of the inventory, to be displayed when it is viewed.
++     * @return The new inventory.
++     */
++    default Inventory createInventory(InventoryHolder owner, InventoryType type, net.kyori.adventure.text.Component title) {
++        return createInventory(owner, type, net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(title));
++    }
++
++    /**
++     * Creates an empty inventory of type {@link InventoryType#CHEST} with the
++     * specified size and title.
++     *
++     * @param owner the holder of the inventory, or null to indicate no holder
++     * @param size a multiple of 9 as the size of inventory to create
++     * @param title the title of the inventory, displayed when inventory is
++     *     viewed
++     * @return a new inventory
++     * @throws IllegalArgumentException if the size is not a multiple of 9
++     */
++    default Inventory createInventory(InventoryHolder owner, int size, net.kyori.adventure.text.Component title) throws IllegalArgumentException {
++        return createInventory(owner, size, net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(title));
++    }
++    // PandaSpigot end
++
+     /**
+      * Gets user-specified limit for number of monsters that can spawn in a
+      * chunk.
+@@ -842,6 +911,26 @@ public interface Server extends PluginMessageRecipient {
+      */
+     String getShutdownMessage();
+ 
++    // PandaSpigot start - Adventure
++    /**
++     * Gets the message that is displayed on the server list.
++     *
++     * @return the servers MOTD
++     */
++    default net.kyori.adventure.text.Component motd() {
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(getMotd());
++    }
++
++    /**
++     * Gets the default message that is displayed when the server is stopped.
++     *
++     * @return the shutdown message
++     */
++    default net.kyori.adventure.text.Component shutdownMessage() {
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(getShutdownMessage());
++    }
++    // PandaSpigot end
++
+     /**
+      * Gets the current warning state for the server.
+      *
+diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
+index e1d61e63798aa7e70974e52a7a49f590ec78e5ff..36a07f027fb05eba32b08e3a566486a02621c663 100644
+--- a/src/main/java/org/bukkit/World.java
++++ b/src/main/java/org/bukkit/World.java
+@@ -20,7 +20,7 @@ import org.bukkit.util.Vector;
+ /**
+  * Represents a world, which may contain entities, chunks and blocks
+  */
+-public interface World extends PluginMessageRecipient, Metadatable {
++public interface World extends PluginMessageRecipient, Metadatable, net.kyori.adventure.audience.ForwardingAudience { // PandaSpigot - Adventure
+ 
+     /**
+      * Gets the {@link Block} at the given coordinates
+@@ -450,6 +450,13 @@ public interface World extends PluginMessageRecipient, Metadatable {
+      */
+     public List<Player> getPlayers();
+ 
++    // PandaSpigot start - Adventure
++    @Override
++    default Iterable<? extends net.kyori.adventure.audience.Audience> audiences() {
++        return this.getPlayers();
++    }
++    // PandaSpigot end
++
+     /**
+      * Returns a list of entities within a bounding box centered around a Location.
+      *
+diff --git a/src/main/java/org/bukkit/block/Sign.java b/src/main/java/org/bukkit/block/Sign.java
+index 5d7a633dcb3ce53a9178c30d0e11161c0cb40c08..452e540ade45138d8093861447e4fc0265836bfc 100644
+--- a/src/main/java/org/bukkit/block/Sign.java
++++ b/src/main/java/org/bukkit/block/Sign.java
+@@ -34,4 +34,36 @@ public interface Sign extends BlockState {
+      * @throws IndexOutOfBoundsException If the index is out of the range 0..3
+      */
+     public void setLine(int index, String line) throws IndexOutOfBoundsException;
++
++    // PandaSpigot start - Adventure
++    /**
++     * Gets all the lines of text currently on this sign.
++     *
++     * @return List of Components containing each line of text
++     */
++    public java.util.List<net.kyori.adventure.text.Component> lines();
++
++    /**
++     * Gets the line of text at the specified index.
++     * <p>
++     * For example, line(0) will return the first line of text.
++     *
++     * @param index Line number to get the text from, starting at 0
++     * @throws IndexOutOfBoundsException Thrown when the line does not exist
++     * @return Text on the given line
++     */
++    public net.kyori.adventure.text.Component line(int index) throws IndexOutOfBoundsException;
++
++    /**
++     * Sets the line of text at the specified index.
++     * <p>
++     * For example, line(0, Component.text("Line One")) will set the first line of text to
++     * "Line One".
++     *
++     * @param index Line number to set the text at, starting from 0
++     * @param line New text to set at the specified index
++     * @throws IndexOutOfBoundsException If the index is out of the range 0..3
++     */
++    public void line(int index, net.kyori.adventure.text.Component line) throws IndexOutOfBoundsException;
++    // PandaSpigot end
+ }
+diff --git a/src/main/java/org/bukkit/command/Command.java b/src/main/java/org/bukkit/command/Command.java
+index c126a1e7e68fd8b81e51d8bdb10dd24eccd9db63..627f3b8e88e5d54fb98ee26cf029fd9ae54933f8 100644
+--- a/src/main/java/org/bukkit/command/Command.java
++++ b/src/main/java/org/bukkit/command/Command.java
+@@ -31,7 +31,7 @@ public abstract class Command {
+     protected String description = "";
+     protected String usageMessage;
+     private String permission;
+-    private String permissionMessage;
++    private net.kyori.adventure.text.Component permissionMessage; // PandaSpigot - Adventure
+     public co.aikar.timings.Timing timings; // Spigot
+     public String getTimingName() {return getName();} // Spigot
+ 
+@@ -199,10 +199,10 @@ public abstract class Command {
+ 
+         if (permissionMessage == null) {
+             target.sendMessage(ChatColor.RED + "I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is in error.");
+-        } else if (permissionMessage.length() != 0) {
+-            for (String line : permissionMessage.replace("<permission>", permission).split("\n")) {
+-                target.sendMessage(line);
+-            }
++        // PandaSpigot start - Adventure
++        } else if (!permissionMessage.equals(net.kyori.adventure.text.Component.empty())) {
++            target.sendMessage(permissionMessage.replaceText(net.kyori.adventure.text.TextReplacementConfig.builder().matchLiteral("<permission>").replacement(permission).build()));
++        // PandaSpigot end
+         }
+ 
+         return false;
+@@ -326,7 +326,7 @@ public abstract class Command {
+      * @return Permission check failed message
+      */
+     public String getPermissionMessage() {
+-        return permissionMessage;
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serializeOrNull(permissionMessage); // PandaSpigot - Adventure
+     }
+ 
+     /**
+@@ -385,7 +385,7 @@ public abstract class Command {
+      * @return this command object, for chaining
+      */
+     public Command setPermissionMessage(String permissionMessage) {
+-        this.permissionMessage = permissionMessage;
++        this.permissionMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserializeOrNull(permissionMessage); // PandaSpigot - Adventure
+         return this;
+     }
+ 
+@@ -400,6 +400,26 @@ public abstract class Command {
+         return this;
+     }
+ 
++    // PandaSpigot start - Adventure
++    /**
++     * Gets the permission message.
++     *
++     * @return the permission message
++     */
++    public net.kyori.adventure.text.Component permissionMessage() {
++        return permissionMessage;
++    }
++
++    /**
++     * Sets the permission message.
++     *
++     * @param permissionMessage the permission message
++     */
++    public void permissionMessage(net.kyori.adventure.text.Component permissionMessage) {
++        this.permissionMessage = permissionMessage;
++    }
++    // PandaSpigot end
++
+     public static void broadcastCommandMessage(CommandSender source, String message) {
+         broadcastCommandMessage(source, message, true);
+     }
+diff --git a/src/main/java/org/bukkit/command/CommandSender.java b/src/main/java/org/bukkit/command/CommandSender.java
+index 148756b9ca60beeb7643ab584dbfcb6defec8d54..d4feeaa1f604a529f2f6c021618344a131af95ee 100644
+--- a/src/main/java/org/bukkit/command/CommandSender.java
++++ b/src/main/java/org/bukkit/command/CommandSender.java
+@@ -3,7 +3,7 @@ package org.bukkit.command;
+ import org.bukkit.Server;
+ import org.bukkit.permissions.Permissible;
+ 
+-public interface CommandSender extends Permissible {
++public interface CommandSender extends Permissible, net.kyori.adventure.audience.Audience { // PandaSpigot - Adventure
+ 
+     /**
+      * Sends this sender a message
+@@ -19,6 +19,47 @@ public interface CommandSender extends Permissible {
+      */
+     public void sendMessage(String[] messages);
+ 
++    // PandaSpigot start - Adventure
++    @Override
++    default void sendMessage(net.kyori.adventure.identity.Identity source, net.kyori.adventure.text.Component message, net.kyori.adventure.audience.MessageType type) {
++        this.sendMessage(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(message));
++    }
++
++    /**
++     * Sends a message with the MiniMessage format to the command sender.
++     * <p>
++     * See <a href="https://docs.advntr.dev/minimessage/">MiniMessage docs</a>
++     * for more information on the format.
++     *
++     * @param message MiniMessage content
++     */
++    default void sendRichMessage(String message) {
++        this.sendMessage(net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().deserialize(message, this));
++    }
++
++    /**
++     * Sends a message with the MiniMessage format to the command sender.
++     * <p>
++     * See <a href="https://docs.advntr.dev/minimessage/">MiniMessage docs</a> and <a href="https://docs.advntr.dev/minimessage/dynamic-replacements">MiniMessage Placeholders docs</a>
++     * for more information on the format.
++     *
++     * @param message MiniMessage content
++     * @param resolvers resolvers to use
++     */
++    default void sendRichMessage(String message, net.kyori.adventure.text.minimessage.tag.resolver.TagResolver... resolvers) {
++        this.sendMessage(net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().deserialize(message, this, resolvers));
++    }
++
++    /**
++     *  Sends a plain message to the command sender.
++     *
++     * @param message plain message
++     */
++    default void sendPlainMessage(String message) {
++        this.sendMessage(net.kyori.adventure.text.Component.text(message));
++    }
++    // PandaSpigot end
++
+     /**
+      * Returns the server instance that this command is running on
+      *
+diff --git a/src/main/java/org/bukkit/command/ProxiedCommandSender.java b/src/main/java/org/bukkit/command/ProxiedCommandSender.java
+index 24c4ebad5326c56d3cc30a745c897431ec947248..325104b3dbdc7c874b04e639b7a1fa84f69c80be 100644
+--- a/src/main/java/org/bukkit/command/ProxiedCommandSender.java
++++ b/src/main/java/org/bukkit/command/ProxiedCommandSender.java
+@@ -1,7 +1,7 @@
+ 
+ package org.bukkit.command;
+ 
+-public interface ProxiedCommandSender extends CommandSender {
++public interface ProxiedCommandSender extends CommandSender, net.kyori.adventure.audience.ForwardingAudience.Single { // PandaSpigot - Adventure
+ 
+     /**
+      * Returns the CommandSender which triggered this proxied command
+@@ -17,4 +17,16 @@ public interface ProxiedCommandSender extends CommandSender {
+      */
+     CommandSender getCallee();
+ 
++    // PandaSpigot start - Adventure
++    @Override
++    default void sendMessage(net.kyori.adventure.identity.Identity source, net.kyori.adventure.text.Component message, net.kyori.adventure.audience.MessageType type) {
++        net.kyori.adventure.audience.ForwardingAudience.Single.super.sendMessage(source, message, type);
++    }
++
++    @Override
++    default net.kyori.adventure.audience.Audience audience() {
++        return this.getCaller();
++    }
++    // PandaSpigot end
++
+ }
+diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
+index 7fb08af407dcacfbe37222dfd66064ffc3dd6963..5b0cfaf76a6f2d178e9fd50ce6123955863c16c3 100644
+--- a/src/main/java/org/bukkit/entity/Entity.java
++++ b/src/main/java/org/bukkit/entity/Entity.java
+@@ -322,6 +322,37 @@ public interface Entity extends Metadatable, CommandSender {
+      */
+     public String getCustomName();
+ 
++
++    // PandaSpigot start - Adventure
++    /**
++     * Gets the custom name on a mob. If there is no name this method will
++     * return null.
++     * <p>
++     * This value has no effect on players, they will always use their real
++     * name.
++     *
++     * @return name of the mob or null
++     */
++    default net.kyori.adventure.text.Component customName() {
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserializeOrNull(getCustomName());
++    }
++
++    /**
++     * Sets a custom name on a mob. This name will be used in death messages
++     * and can be sent to the client as a nameplate over the mob.
++     * <p>
++     * Setting the name to null or an empty string will clear it.
++     * <p>
++     * This value has no effect on players, they will always use their real
++     * name.
++     *
++     * @param customName the name to set
++     */
++    default void customName(net.kyori.adventure.text.Component customName) {
++        setCustomName(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serializeOrNull(customName));
++    }
++    // PandaSpigot end
++
+     /**
+      * Sets whether or not to display the mob's custom name client side. The
+      * name will be displayed above the mob similarly to a player.
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index ec6187582a696f5705390eac92a04a36511c3a6c..751f2f0f6b9fb4af753584c890555dfa92d74fa1 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -26,7 +26,7 @@ import org.github.paperspigot.Title;
+ /**
+  * Represents a player, connected or not
+  */
+-public interface Player extends HumanEntity, Conversable, CommandSender, OfflinePlayer, PluginMessageRecipient {
++public interface Player extends HumanEntity, Conversable, CommandSender, OfflinePlayer, PluginMessageRecipient, net.kyori.adventure.identity.Identified { // PandaSpigot - Adventure
+ 
+     /**
+      * Gets the "friendly" name to display of this player. This may include
+@@ -80,6 +80,60 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
+      */
+     public void setPlayerListName(String name);
+ 
++    // PandaSpigot start - Adventure
++    /**
++     * Gets the "friendly" name to display of this player. This may include
++     * color.
++     * <p>
++     * Note that this name will not be displayed in game, only in chat and
++     * places defined by plugins.
++     *
++     * @return the friendly name
++     */
++    public net.kyori.adventure.text.Component displayName();
++
++    /**
++     * Sets the "friendly" name to display of this player. This may include
++     * color.
++     * <p>
++     * Note that this name will not be displayed in game, only in chat and
++     * places defined by plugins.
++     *
++     * @param displayName The new display name.
++     */
++    public void displayName(net.kyori.adventure.text.Component displayName);
++
++    /**
++     * Gets the name that is shown on the player list.
++     *
++     * @return the player list name
++     */
++    public net.kyori.adventure.text.Component playerListName();
++
++    /**
++     * Sets the name that is shown on the in-game player list.
++     * <p>
++     * The name cannot be longer than 16 characters, but {@link ChatColor} is
++     * supported.
++     * <p>
++     * If the value is null, the name will be identical to {@link #getName()}.
++     * <p>
++     * This name is case-sensitive and unique, two names with different casing
++     * will appear as two different people. If a player joins afterward with
++     * a name that conflicts with a player's custom list name, the joining
++     * player's player list name will have a random number appended to it (1-2
++     * characters long in the default implementation). If the joining player's
++     * name is 15 or 16 characters long, part of the name will be truncated at
++     * the end to allow the addition of the two digits.
++     *
++     * @param playerListName new player list name
++     * @throws IllegalArgumentException if the name is already used by someone
++     *     else
++     * @throws IllegalArgumentException if the length of the name is too long
++     */
++    public void playerListName(net.kyori.adventure.text.Component playerListName);
++    // PandaSpigot end
++
+     /**
+      * Set the target of the player's compass.
+      *
+@@ -115,6 +169,15 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
+      */
+     public void kickPlayer(String message);
+ 
++    // PandaSpigot start - Adventure
++    /**
++     * Kicks player with custom kick message.
++     *
++     * @param message kick message
++     */
++    public void kick(net.kyori.adventure.text.Component message);
++    // PandaSpigot end
++
+     /**
+      * Says a message (or runs a command).
+      *
+@@ -364,6 +427,22 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
+      */
+     public void setPlayerListHeaderFooter(net.md_5.bungee.api.chat.BaseComponent header, net.md_5.bungee.api.chat.BaseComponent footer);
+ 
++    // PandaSpigot start - Adventure
++    /**
++     * Gets the currently displayed player list header for this player.
++     *
++     * @return player list header or null
++     */
++    public net.kyori.adventure.text.Component playerListHeader();
++
++    /**
++     * Gets the current displayed player list footer for this player.
++     *
++     * @return player list footer or null
++     */
++    public net.kyori.adventure.text.Component playerListFooter();
++    // PandaSpigot end
++
+     /**
+      * Update the times for titles displayed to the player
+      *
+@@ -1362,4 +1441,11 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
+ 
+     Spigot spigot();
+     // Spigot end
++
++    // PandaSpigot start - Adventure
++    @Override
++    default net.kyori.adventure.identity.Identity identity() {
++        return net.kyori.adventure.identity.Identity.identity(this.getUniqueId());
++    }
++    // PandaSpigot end
+ }
+diff --git a/src/main/java/org/bukkit/event/block/SignChangeEvent.java b/src/main/java/org/bukkit/event/block/SignChangeEvent.java
+index 83188cf583695c55708c49b2596bc030ef9e8322..634ade9e9e74072f746263438b56105f52ec488f 100644
+--- a/src/main/java/org/bukkit/event/block/SignChangeEvent.java
++++ b/src/main/java/org/bukkit/event/block/SignChangeEvent.java
+@@ -14,13 +14,26 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean cancel = false;
+     private final Player player;
+-    private final String[] lines;
++    private final net.kyori.adventure.text.Component[] lines; // PandaSpigot - Adventure
+ 
+     public SignChangeEvent(final Block theBlock, final Player thePlayer, final String[] theLines) {
++        super(theBlock);
++        this.player = thePlayer;
++        // PandaSpigot start - Adventure
++        this.lines = new net.kyori.adventure.text.Component[theLines.length];
++        for (int i = 0; i < theLines.length; i++) {
++            this.lines[i] = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(theLines[i]);
++        }
++        // PandaSpigot end
++    }
++
++    // PandaSpigot start - Adventure
++    public SignChangeEvent(final Block theBlock, final Player thePlayer, final net.kyori.adventure.text.Component[] theLines) {
+         super(theBlock);
+         this.player = thePlayer;
+         this.lines = theLines;
+     }
++    // PandaSpigot end
+ 
+     /**
+      * Gets the player changing the sign involved in this event.
+@@ -37,7 +50,7 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
+      * @return the String array for the sign's lines new text
+      */
+     public String[] getLines() {
+-        return lines;
++        return java.util.Arrays.stream(lines).map(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection()::serialize).toArray(String[]::new); // PandaSpigot - Adventure
+     }
+ 
+     /**
+@@ -50,7 +63,7 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
+      *     or < 0}
+      */
+     public String getLine(int index) throws IndexOutOfBoundsException {
+-        return lines[index];
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(lines[index]); // PandaSpigot - Adventure
+     }
+ 
+     /**
+@@ -62,8 +75,44 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
+      *     or < 0}
+      */
+     public void setLine(int index, String line) throws IndexOutOfBoundsException {
++        lines[index] = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(line); // PandaSpigot - Adventure
++    }
++
++    // PandaSpigot start - Adventure
++    /**
++     * Gets all the lines of text from the sign involved in this event.
++     *
++     * @return the Component list for the sign's lines new text
++     */
++    public java.util.List<net.kyori.adventure.text.Component> lines() {
++        return java.util.Arrays.asList(lines);
++    }
++
++    /**
++     * Gets a single line of text from the sign involved in this event.
++     *
++     * @param index index of the line to get
++     * @return the Component containing the line of text associated with the
++     *     provided index
++     * @throws IndexOutOfBoundsException thrown when the provided index is {@literal > 3
++     *     or < 0}
++     */
++    public net.kyori.adventure.text.Component line(int index) throws IndexOutOfBoundsException {
++        return lines[index];
++    }
++
++    /**
++     * Sets a single line for the sign involved in this event
++     *
++     * @param index index of the line to set
++     * @param line text to set
++     * @throws IndexOutOfBoundsException thrown when the provided index is {@literal > 3
++     *     or < 0}
++     */
++    public void line(int index, net.kyori.adventure.text.Component line) throws IndexOutOfBoundsException {
+         lines[index] = line;
+     }
++    // PandaSpigot end
+ 
+     public boolean isCancelled() {
+         return cancel;
+diff --git a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
+index aad03549523391d22e574778250f8169bbac33f6..de569c5eaeeb7de954017b7b4e80f4a89739e1bf 100644
+--- a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
++++ b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
+@@ -10,7 +10,7 @@ import org.bukkit.inventory.ItemStack;
+  */
+ public class PlayerDeathEvent extends EntityDeathEvent {
+     private int newExp = 0;
+-    private String deathMessage = "";
++    private net.kyori.adventure.text.Component deathMessage; // PandaSpigot - Adventure
+     private int newLevel = 0;
+     private int newTotalExp = 0;
+     private boolean keepLevel = false;
+@@ -25,12 +25,30 @@ public class PlayerDeathEvent extends EntityDeathEvent {
+     }
+ 
+     public PlayerDeathEvent(final Player player, final List<ItemStack> drops, final int droppedExp, final int newExp, final int newTotalExp, final int newLevel, final String deathMessage) {
++        super(player, drops, droppedExp);
++        this.newExp = newExp;
++        this.newTotalExp = newTotalExp;
++        this.newLevel = newLevel;
++        this.deathMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(deathMessage); // PandaSpigot - Adventure
++    }
++
++    // PandaSpigot start - Adventure
++    public PlayerDeathEvent(final Player player, final List<ItemStack> drops, final int droppedExp, final net.kyori.adventure.text.Component deathMessage) {
++        this(player, drops, droppedExp, 0, deathMessage);
++    }
++
++    public PlayerDeathEvent(final Player player, final List<ItemStack> drops, final int droppedExp, final int newExp, final net.kyori.adventure.text.Component deathMessage) {
++        this(player, drops, droppedExp, newExp, 0, 0, deathMessage);
++    }
++
++    public PlayerDeathEvent(final Player player, final List<ItemStack> drops, final int droppedExp, final int newExp, final int newTotalExp, final int newLevel, final net.kyori.adventure.text.Component deathMessage) {
+         super(player, drops, droppedExp);
+         this.newExp = newExp;
+         this.newTotalExp = newTotalExp;
+         this.newLevel = newLevel;
+         this.deathMessage = deathMessage;
+     }
++    // PandaSpigot end
+ 
+     @Override
+     public Player getEntity() {
+@@ -43,7 +61,7 @@ public class PlayerDeathEvent extends EntityDeathEvent {
+      * @param deathMessage Message to appear to other players on the server.
+      */
+     public void setDeathMessage(String deathMessage) {
+-        this.deathMessage = deathMessage;
++        this.deathMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserializeOrNull(deathMessage); // PandaSpigot - Adventure
+     }
+ 
+     /**
+@@ -52,8 +70,28 @@ public class PlayerDeathEvent extends EntityDeathEvent {
+      * @return Message to appear to other players on the server.
+      */
+     public String getDeathMessage() {
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serializeOrNull(deathMessage); // PandaSpigot - Adventure
++    }
++
++    // PandaSpigot start - Adventure
++    /**
++     * Set the death message that will appear to everyone on the server.
++     *
++     * @param deathMessage Message to appear to other players on the server.
++     */
++    public void deathMessage(net.kyori.adventure.text.Component deathMessage) {
++        this.deathMessage = deathMessage;
++    }
++
++    /**
++     * Get the death message that will appear to everyone on the server.
++     *
++     * @return Message to appear to other players on the server.
++     */
++    public net.kyori.adventure.text.Component deathMessage() {
+         return deathMessage;
+     }
++    // PandaSpigot end
+ 
+     /**
+      * Gets how much EXP the Player should have at respawn.
+diff --git a/src/main/java/org/bukkit/event/inventory/InventoryType.java b/src/main/java/org/bukkit/event/inventory/InventoryType.java
+index c36e0467281fef62c8362640df1b9e4990562d47..043ac88d080efdc475decd665ef990ce9c574b68 100644
+--- a/src/main/java/org/bukkit/event/inventory/InventoryType.java
++++ b/src/main/java/org/bukkit/event/inventory/InventoryType.java
+@@ -73,10 +73,12 @@ public enum InventoryType {
+ 
+     private final int size;
+     private final String title;
++    private final net.kyori.adventure.text.Component adventure$title; // PandaSpigot - Adventure
+ 
+     private InventoryType(int defaultSize, String defaultTitle) {
+         size = defaultSize;
+         title = defaultTitle;
++        adventure$title = net.kyori.adventure.text.Component.text(defaultTitle);
+     }
+ 
+     public int getDefaultSize() {
+@@ -87,6 +89,12 @@ public enum InventoryType {
+         return title;
+     }
+ 
++    // PandaSpigot start - Adventure
++    public net.kyori.adventure.text.Component defaultTitle() {
++        return adventure$title;
++    }
++    // PandaSpigot end
++
+     public enum SlotType {
+         /**
+          * A result slot in a furnace or crafting inventory.
+diff --git a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
+index 62562d3503d856a3dce22c3e972543f1a2d63cca..076c6e83ff7fa4fb55c09da8263a46c7597101b7 100644
+--- a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
++++ b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
+@@ -14,7 +14,7 @@ import org.bukkit.event.HandlerList;
+ public class AsyncPlayerPreLoginEvent extends Event {
+     private static final HandlerList handlers = new HandlerList();
+     private Result result;
+-    private String message;
++    private net.kyori.adventure.text.Component message; // PandaSpigot - Adventure
+     //private final String name; // PandaSpigot - Not used anymore
+     private final InetAddress ipAddress;
+     //private final UUID uniqueId; // PandaSpigot - Not used anymore
+@@ -51,7 +51,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
+         this.profile = profile;
+     // PandaSpigot end
+         this.result = Result.ALLOWED;
+-        this.message = "";
++        this.message = net.kyori.adventure.text.Component.empty(); // PandaSpigot - Adventure
+         //this.name = name; // PandaSpigot - Not used anymore
+         this.ipAddress = ipAddress;
+         //this.uniqueId = uniqueId; // PandaSpigot - Not used anymore
+@@ -108,7 +108,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
+      * @return Current kick message
+      */
+     public String getKickMessage() {
+-        return message;
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(message); // PandaSpigot - Adventure
+     }
+ 
+     /**
+@@ -117,7 +117,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
+      * @param message New kick message
+      */
+     public void setKickMessage(final String message) {
+-        this.message = message;
++        this.message = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(message); // PandaSpigot - Adventure
+     }
+ 
+     /**
+@@ -125,7 +125,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
+      */
+     public void allow() {
+         result = Result.ALLOWED;
+-        message = "";
++        message = net.kyori.adventure.text.Component.empty(); // PandaSpigot - Adventure
+     }
+ 
+     /**
+@@ -136,7 +136,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
+      */
+     public void disallow(final Result result, final String message) {
+         this.result = result;
+-        this.message = message;
++        this.message = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(message); // PandaSpigot - Adventure
+     }
+ 
+     /**
+@@ -151,9 +151,56 @@ public class AsyncPlayerPreLoginEvent extends Event {
+     @Deprecated
+     public void disallow(final PlayerPreLoginEvent.Result result, final String message) {
+         this.result = result == null ? null : Result.valueOf(result.name());
++        this.message = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(message); // PandaSpigot - Adventure
++    }
++
++    // PandaSpigot start - Adventure
++    /**
++     * Gets the current kick message that will be used if getResult() !=
++     * Result.ALLOWED
++     *
++     * @return Current kick message
++     */
++    public net.kyori.adventure.text.Component kickMessage() {
++        return message;
++    }
++
++    /**
++     * Sets the kick message to display if getResult() != Result.ALLOWED
++     *
++     * @param message New kick message
++     */
++    public void kickMessage(net.kyori.adventure.text.Component message) {
+         this.message = message;
+     }
+ 
++    /**
++     * Disallows the player from logging in, with the given reason
++     *
++     * @param result New result for disallowing the player
++     * @param message Kick message to display to the user
++     */
++    public void disallow(final Result result, final net.kyori.adventure.text.Component message) {
++        this.result = result;
++        this.message = message;
++    }
++
++    /**
++     * Disallows the player from logging in, with the given reason
++     *
++     * @param result New result for disallowing the player
++     * @param message Kick message to display to the user
++     * @deprecated This method uses a deprecated enum from {@link
++     *     PlayerPreLoginEvent}
++     * @see #disallow(Result, net.kyori.adventure.text.Component)
++     */
++    @Deprecated
++    public void disallow(final PlayerPreLoginEvent.Result result, final net.kyori.adventure.text.Component message) {
++        this.result = result == null ? null : Result.valueOf(result.name());
++        this.message = message;
++    }
++    // PandaSpigot end
++
+     /**
+      * Gets the player's name.
+      *
+diff --git a/src/main/java/org/bukkit/event/player/PlayerJoinEvent.java b/src/main/java/org/bukkit/event/player/PlayerJoinEvent.java
+index e7481f92c758396ea2035d404042d5fd8193def0..5ea0f4a9a9d320cb78af81d51abe058ff783983e 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerJoinEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerJoinEvent.java
+@@ -8,12 +8,19 @@ import org.bukkit.event.HandlerList;
+  */
+ public class PlayerJoinEvent extends PlayerEvent {
+     private static final HandlerList handlers = new HandlerList();
+-    private String joinMessage;
++    private net.kyori.adventure.text.Component joinMessage; // PandaSpigot - Adventure
+ 
+     public PlayerJoinEvent(final Player playerJoined, final String joinMessage) {
++        super(playerJoined);
++        this.joinMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(joinMessage); // PandaSpigot - Adventure
++    }
++
++    // PandaSpigot start - Adventure
++    public PlayerJoinEvent(final Player playerJoined, final net.kyori.adventure.text.Component joinMessage) {
+         super(playerJoined);
+         this.joinMessage = joinMessage;
+     }
++    // PandaSpigot end
+ 
+     /**
+      * Gets the join message to send to all online players
+@@ -21,7 +28,7 @@ public class PlayerJoinEvent extends PlayerEvent {
+      * @return string join message
+      */
+     public String getJoinMessage() {
+-        return joinMessage;
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serializeOrNull(joinMessage); // PandaSpigot - Adventure
+     }
+ 
+     /**
+@@ -30,8 +37,28 @@ public class PlayerJoinEvent extends PlayerEvent {
+      * @param joinMessage join message
+      */
+     public void setJoinMessage(String joinMessage) {
++        this.joinMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserializeOrNull(joinMessage); // PandaSpigot - Adventure
++    }
++
++    // PandaSpigot start - Adventure
++    /**
++     * Gets the join message to send to all online players
++     *
++     * @return Component join message
++     */
++    public net.kyori.adventure.text.Component joinMessage() {
++        return joinMessage;
++    }
++
++    /**
++     * Sets the join message to send to all online players
++     *
++     * @param joinMessage join message
++     */
++    public void joinMessage(net.kyori.adventure.text.Component joinMessage) {
+         this.joinMessage = joinMessage;
+     }
++    // PandaSpigot end
+ 
+     @Override
+     public HandlerList getHandlers() {
+diff --git a/src/main/java/org/bukkit/event/player/PlayerKickEvent.java b/src/main/java/org/bukkit/event/player/PlayerKickEvent.java
+index 39e81b67840eadf4f41aab8a8eb4549f9f7043fa..f13bbbaaba286fe436a497dab7755b8819b622af 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerKickEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerKickEvent.java
+@@ -9,16 +9,29 @@ import org.bukkit.event.HandlerList;
+  */
+ public class PlayerKickEvent extends PlayerEvent implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+-    private String leaveMessage;
+-    private String kickReason;
++    // PandaSpigot start - Adventure
++    private net.kyori.adventure.text.Component leaveMessage;
++    private net.kyori.adventure.text.Component kickReason;
++    // PandaSpigot end
+     private Boolean cancel;
+ 
+     public PlayerKickEvent(final Player playerKicked, final String kickReason, final String leaveMessage) {
++        super(playerKicked);
++        // PandaSpigot start - Adventure
++        this.kickReason = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(kickReason);
++        this.leaveMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(leaveMessage);
++        // PandaSpigot end
++        this.cancel = false;
++    }
++
++    // PandaSpigot start - Adventure
++    public PlayerKickEvent(final Player playerKicked, final net.kyori.adventure.text.Component kickReason, final net.kyori.adventure.text.Component leaveMessage) {
+         super(playerKicked);
+         this.kickReason = kickReason;
+         this.leaveMessage = leaveMessage;
+         this.cancel = false;
+     }
++    // PandaSpigot end
+ 
+     /**
+      * Gets the reason why the player is getting kicked
+@@ -26,7 +39,7 @@ public class PlayerKickEvent extends PlayerEvent implements Cancellable {
+      * @return string kick reason
+      */
+     public String getReason() {
+-        return kickReason;
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(kickReason);
+     }
+ 
+     /**
+@@ -35,7 +48,7 @@ public class PlayerKickEvent extends PlayerEvent implements Cancellable {
+      * @return string kick reason
+      */
+     public String getLeaveMessage() {
+-        return leaveMessage;
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serializeOrNull(leaveMessage);
+     }
+ 
+     public boolean isCancelled() {
+@@ -52,7 +65,7 @@ public class PlayerKickEvent extends PlayerEvent implements Cancellable {
+      * @param kickReason kick reason
+      */
+     public void setReason(String kickReason) {
+-        this.kickReason = kickReason;
++        this.kickReason = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(kickReason);
+     }
+ 
+     /**
+@@ -61,8 +74,46 @@ public class PlayerKickEvent extends PlayerEvent implements Cancellable {
+      * @param leaveMessage leave message
+      */
+     public void setLeaveMessage(String leaveMessage) {
++        this.leaveMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserializeOrNull(leaveMessage);
++    }
++
++    // PandaSpigot start - Adventure
++    /**
++     * Gets the reason why the player is getting kicked
++     *
++     * @return Component kick reason
++     */
++    public net.kyori.adventure.text.Component reason() {
++        return kickReason;
++    }
++
++    /**
++     * Gets the leave message send to all online players
++     *
++     * @return Component kick reason
++     */
++    public net.kyori.adventure.text.Component leaveMessage() {
++        return leaveMessage;
++    }
++
++    /**
++     * Sets the reason why the player is getting kicked
++     *
++     * @param kickReason kick reason
++     */
++    public void reason(net.kyori.adventure.text.Component kickReason) {
++        this.kickReason = kickReason;
++    }
++
++    /**
++     * Sets the leave message send to all online players
++     *
++     * @param leaveMessage leave message
++     */
++    public void leaveMessage(net.kyori.adventure.text.Component leaveMessage) {
+         this.leaveMessage = leaveMessage;
+     }
++    // PandaSpigot end
+ 
+     @Override
+     public HandlerList getHandlers() {
+diff --git a/src/main/java/org/bukkit/event/player/PlayerLocaleChangeEvent.java b/src/main/java/org/bukkit/event/player/PlayerLocaleChangeEvent.java
+index 3efd15972e79afebce3d30a24b7dabdf8b963d7c..f856c68a4de9dd6d88673a87e5db3758e1f0444c 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerLocaleChangeEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerLocaleChangeEvent.java
+@@ -10,11 +10,16 @@ public class PlayerLocaleChangeEvent extends PlayerEvent {
+     private static final HandlerList handlers = new HandlerList();
+     private final String oldLocale;
+     private final String newLocale;
++    private final java.util.Locale adventure$oldLocale, adventure$newLocale; // PandaSpigot - Adventure
+ 
+     public PlayerLocaleChangeEvent(final Player player, final String oldLocale, final String newLocale) {
+         super(player);
+         this.oldLocale = oldLocale;
+         this.newLocale = newLocale;
++        // PandaSpigot start - Adventure
++        this.adventure$oldLocale = oldLocale == null ? java.util.Locale.US : net.kyori.adventure.translation.Translator.parseLocale(oldLocale);
++        this.adventure$newLocale = newLocale == null ? java.util.Locale.US : net.kyori.adventure.translation.Translator.parseLocale(newLocale);
++        // PandaSpigot end
+     }
+ 
+     /**
+@@ -35,6 +40,26 @@ public class PlayerLocaleChangeEvent extends PlayerEvent {
+         return newLocale;
+     }
+ 
++    // PandaSpigot start - Adventure
++    /**
++     * Gets the locale the player switched from.
++     *
++     * @return player's old locale
++     */
++    public java.util.Locale oldLocale() {
++        return adventure$oldLocale;
++    }
++
++    /**
++     * Gets the locale the player is changed to.
++     *
++     * @return player's new locale
++     */
++    public java.util.Locale newLocale() {
++        return adventure$newLocale;
++    }
++    // PandaSpigot end
++
+     @Override
+     public HandlerList getHandlers() {
+         return handlers;
+@@ -43,4 +68,4 @@ public class PlayerLocaleChangeEvent extends PlayerEvent {
+     public static HandlerList getHandlerList() {
+         return handlers;
+     }
+-}
+\ No newline at end of file
++}
+diff --git a/src/main/java/org/bukkit/event/player/PlayerLoginEvent.java b/src/main/java/org/bukkit/event/player/PlayerLoginEvent.java
+index 4bc024ffd3f94c161dd9f64ad5c6201c495e08fa..e9a4a227850329ba52f58a99bb9886ab7c04149d 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerLoginEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerLoginEvent.java
+@@ -13,7 +13,7 @@ public class PlayerLoginEvent extends PlayerEvent {
+     private final InetAddress address;
+     private final String hostname;
+     private Result result = Result.ALLOWED;
+-    private String message = "";
++    private net.kyori.adventure.text.Component message = net.kyori.adventure.text.Component.empty(); // PandaSpigot - Adventure
+     private final InetAddress realAddress; // Spigot
+ 
+     /**
+@@ -82,8 +82,26 @@ public class PlayerLoginEvent extends PlayerEvent {
+     public PlayerLoginEvent(final Player player, String hostname, final InetAddress address, final Result result, final String message, final InetAddress realAddress) { // Spigot
+         this(player, hostname, address, realAddress); // Spigot
+         this.result = result;
++        this.message = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(message); // PandaSpigot - Adventure
++    }
++
++    // PandaSpigot start - Adventure
++    /**
++     * This constructor pre-configures the event with a result and message
++     *
++     * @param player The {@link Player} for this event
++     * @param hostname The hostname that was used to connect to the server
++     * @param address The address the player used to connect, provided for
++     *     timing issues
++     * @param result The result status for this event
++     * @param message The message to be displayed if result denies login
++     */
++    public PlayerLoginEvent(final Player player, String hostname, final InetAddress address, final Result result, final net.kyori.adventure.text.Component message, final InetAddress realAddress) {
++        this(player, hostname, address, realAddress);
++        this.result = result;
+         this.message = message;
+     }
++    // PandaSpigot end
+ 
+     // Spigot start
+     /**
+@@ -121,7 +139,7 @@ public class PlayerLoginEvent extends PlayerEvent {
+      * @return Current kick message
+      */
+     public String getKickMessage() {
+-        return message;
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(message); // PandaSpigot - Adventure
+     }
+ 
+     /**
+@@ -130,7 +148,7 @@ public class PlayerLoginEvent extends PlayerEvent {
+      * @param message New kick message
+      */
+     public void setKickMessage(final String message) {
+-        this.message = message;
++        this.message = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(message); // PandaSpigot - Adventure
+     }
+ 
+     /**
+@@ -148,7 +166,7 @@ public class PlayerLoginEvent extends PlayerEvent {
+      */
+     public void allow() {
+         result = Result.ALLOWED;
+-        message = "";
++        message = net.kyori.adventure.text.Component.text(""); // PandaSpigot - Adventure
+     }
+ 
+     /**
+@@ -158,9 +176,41 @@ public class PlayerLoginEvent extends PlayerEvent {
+      * @param message Kick message to display to the user
+      */
+     public void disallow(final Result result, final String message) {
++        this.result = result;
++        this.message = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(message); // PandaSpigot - Adventure
++    }
++
++    // PandaSpigot start - Adventure
++    /**
++     * Gets the current kick message that will be used if getResult() !=
++     * Result.ALLOWED
++     *
++     * @return Current kick message
++     */
++    public net.kyori.adventure.text.Component kickMessage() {
++        return message;
++    }
++
++    /**
++     * Sets the kick message to display if getResult() != Result.ALLOWED
++     *
++     * @param message New kick message
++     */
++    public void kickMessage(final net.kyori.adventure.text.Component message) {
++        this.message = message;
++    }
++
++    /**
++     * Disallows the player from logging in, with the given reason
++     *
++     * @param result New result for disallowing the player
++     * @param message Kick message to display to the user
++     */
++    public void disallow(final Result result, final net.kyori.adventure.text.Component message) {
+         this.result = result;
+         this.message = message;
+     }
++    // PandaSpigot end
+ 
+     /**
+      * Gets the {@link InetAddress} for the Player associated with this event.
+diff --git a/src/main/java/org/bukkit/event/player/PlayerPreLoginEvent.java b/src/main/java/org/bukkit/event/player/PlayerPreLoginEvent.java
+index e8553f0f36b1b25bf44087f8d72fb81d8c8424e5..4686c71ee373cb63a1af994fc8a712c3160d7d81 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerPreLoginEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerPreLoginEvent.java
+@@ -19,7 +19,7 @@ import org.bukkit.event.HandlerList;
+ public class PlayerPreLoginEvent extends Event {
+     private static final HandlerList handlers = new HandlerList();
+     private Result result;
+-    private String message;
++    private net.kyori.adventure.text.Component message; // PandaSpigot - Adventure
+     private final String name;
+     private final InetAddress ipAddress;
+     private final UUID uniqueId;
+@@ -31,7 +31,7 @@ public class PlayerPreLoginEvent extends Event {
+ 
+     public PlayerPreLoginEvent(final String name, final InetAddress ipAddress, final UUID uniqueId) {
+         this.result = Result.ALLOWED;
+-        this.message = "";
++        this.message = net.kyori.adventure.text.Component.empty(); // PandaSpigot - Adventure
+         this.name = name;
+         this.ipAddress = ipAddress;
+         this.uniqueId = uniqueId;
+@@ -62,7 +62,7 @@ public class PlayerPreLoginEvent extends Event {
+      * @return Current kick message
+      */
+     public String getKickMessage() {
+-        return message;
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(message); // PandaSpigot - Adventure
+     }
+ 
+     /**
+@@ -71,7 +71,7 @@ public class PlayerPreLoginEvent extends Event {
+      * @param message New kick message
+      */
+     public void setKickMessage(final String message) {
+-        this.message = message;
++        this.message = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(message); // PandaSpigot - Adventure
+     }
+ 
+     /**
+@@ -79,7 +79,7 @@ public class PlayerPreLoginEvent extends Event {
+      */
+     public void allow() {
+         result = Result.ALLOWED;
+-        message = "";
++        message = net.kyori.adventure.text.Component.empty(); // PandaSpigot - Adventure
+     }
+ 
+     /**
+@@ -89,9 +89,41 @@ public class PlayerPreLoginEvent extends Event {
+      * @param message Kick message to display to the user
+      */
+     public void disallow(final Result result, final String message) {
++        this.result = result;
++        this.message = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(message); // PandaSpigot - Adventure
++    }
++
++    // PandaSpigot start - Adventure
++    /**
++     * Gets the current kick message that will be used if getResult() !=
++     * Result.ALLOWED
++     *
++     * @return Current kick message
++     */
++    public net.kyori.adventure.text.Component kickMessage() {
++        return message;
++    }
++
++    /**
++     * Sets the kick message to display if getResult() != Result.ALLOWED
++     *
++     * @param message New kick message
++     */
++    public void kickMessage(final net.kyori.adventure.text.Component message) {
++        this.message = message;
++    }
++
++    /**
++     * Disallows the player from logging in, with the given reason
++     *
++     * @param result New result for disallowing the player
++     * @param message Kick message to display to the user
++     */
++    public void disallow(final Result result, final net.kyori.adventure.text.Component message) {
+         this.result = result;
+         this.message = message;
+     }
++    // PandaSpigot end
+ 
+     /**
+      * Gets the player's name.
+diff --git a/src/main/java/org/bukkit/event/player/PlayerQuitEvent.java b/src/main/java/org/bukkit/event/player/PlayerQuitEvent.java
+index 5c8dc1b91c297b40e05dcbabf48cc12d194b34eb..37cda58c37d075bf19dce548cf0341232af1d15e 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerQuitEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerQuitEvent.java
+@@ -8,12 +8,19 @@ import org.bukkit.event.HandlerList;
+  */
+ public class PlayerQuitEvent extends PlayerEvent {
+     private static final HandlerList handlers = new HandlerList();
+-    private String quitMessage;
++    private net.kyori.adventure.text.Component quitMessage; // PandaSpigot - Adventure
+ 
+     public PlayerQuitEvent(final Player who, final String quitMessage) {
++        super(who);
++        this.quitMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(quitMessage); // PandaSpigot - Adventure
++    }
++
++    // PandaSpigot start - Adventure
++    public PlayerQuitEvent(final Player who, final net.kyori.adventure.text.Component quitMessage) {
+         super(who);
+         this.quitMessage = quitMessage;
+     }
++    // PandaSpigot end
+ 
+     /**
+      * Gets the quit message to send to all online players
+@@ -21,7 +28,7 @@ public class PlayerQuitEvent extends PlayerEvent {
+      * @return string quit message
+      */
+     public String getQuitMessage() {
+-        return quitMessage;
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serializeOrNull(quitMessage); // PandaSpigot - Adventure
+     }
+ 
+     /**
+@@ -30,8 +37,28 @@ public class PlayerQuitEvent extends PlayerEvent {
+      * @param quitMessage quit message
+      */
+     public void setQuitMessage(String quitMessage) {
++        this.quitMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserializeOrNull(quitMessage); // PandaSpigot - Adventure
++    }
++
++    // PandaSpigot start - Adventure
++    /**
++     * Gets the quit message to send to all online players
++     *
++     * @return string quit message
++     */
++    public net.kyori.adventure.text.Component quitMessage() {
++        return quitMessage;
++    }
++
++    /**
++     * Sets the quit message to send to all online players
++     *
++     * @param quitMessage quit message
++     */
++    public void quitMessage(net.kyori.adventure.text.Component quitMessage) {
+         this.quitMessage = quitMessage;
+     }
++    // PandaSpigot end
+ 
+     @Override
+     public HandlerList getHandlers() {
+diff --git a/src/main/java/org/bukkit/event/server/ServerListPingEvent.java b/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
+index 3c38d85735d37b401061feae686dea50adb5b650..bcf68ca2bea489e7d39e90e4157f8cca5a150eda 100644
+--- a/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
++++ b/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
+@@ -16,7 +16,7 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
+     private static final int MAGIC_PLAYER_COUNT = Integer.MIN_VALUE;
+     private static final HandlerList handlers = new HandlerList();
+     private final InetAddress address;
+-    private String motd;
++    private net.kyori.adventure.text.Component motd; // PandaSpigot - Adventure
+     private final int numPlayers;
+     private int maxPlayers;
+ 
+@@ -24,7 +24,7 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
+         super(); // Paper - Is this event being fired async?
+         Validate.isTrue(numPlayers >= 0, "Cannot have negative number of players online", numPlayers);
+         this.address = address;
+-        this.motd = motd;
++        this.motd = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(motd); // PandaSpigot - Adventure
+         this.numPlayers = numPlayers;
+         this.maxPlayers = maxPlayers;
+     }
+@@ -42,9 +42,37 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
+         super(); // Paper - Is this event being fired async?
+         this.numPlayers = MAGIC_PLAYER_COUNT;
+         this.address = address;
++        this.motd = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(motd); // PandaSpigot - Adventure
++        this.maxPlayers = maxPlayers;
++    }
++
++    // PandaSpigot start - Adventure
++    public ServerListPingEvent(final InetAddress address, final net.kyori.adventure.text.Component motd, final int numPlayers, final int maxPlayers) {
++        super();
++        Validate.isTrue(numPlayers >= 0, "Cannot have negative number of players online", numPlayers);
++        this.address = address;
++        this.motd = motd;
++        this.numPlayers = numPlayers;
++        this.maxPlayers = maxPlayers;
++    }
++
++    /**
++     * This constructor is intended for implementations that provide the
++     * {@link #iterator()} method, thus provided the {@link #getNumPlayers()}
++     * count.
++     *
++     * @param address the address of the pinger
++     * @param motd the message of the day
++     * @param maxPlayers the max number of players
++     */
++    protected ServerListPingEvent(final InetAddress address, final net.kyori.adventure.text.Component motd, final int maxPlayers) {
++        super();
++        this.numPlayers = MAGIC_PLAYER_COUNT;
++        this.address = address;
+         this.motd = motd;
+         this.maxPlayers = maxPlayers;
+     }
++    // PandaSpigot end
+ 
+     /**
+      * Get the address the ping is coming from.
+@@ -61,7 +89,7 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
+      * @return the message of the day
+      */
+     public String getMotd() {
+-        return motd;
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(motd); // PandaSpigot - Adventure
+     }
+ 
+     /**
+@@ -70,8 +98,28 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
+      * @param motd the message of the day
+      */
+     public void setMotd(String motd) {
++        this.motd = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(motd); // PandaSpigot - Adventure
++    }
++
++    // PandaSpigot start - Adventure
++    /**
++     * Get the message of the day message.
++     *
++     * @return the message of the day
++     */
++    public net.kyori.adventure.text.Component motd() {
++        return motd;
++    }
++
++    /**
++     * Change the message of the day message.
++     *
++     * @param motd the message of the day
++     */
++    public void motd(net.kyori.adventure.text.Component motd) {
+         this.motd = motd;
+     }
++    // PandaSpigot end
+ 
+     /**
+      * Get the number of players sent.
+diff --git a/src/main/java/org/bukkit/inventory/Inventory.java b/src/main/java/org/bukkit/inventory/Inventory.java
+index da5d83e021d3dacd1032750432bb02658170260d..60155118eeda28f78379e3809b2c25851abae84e 100644
+--- a/src/main/java/org/bukkit/inventory/Inventory.java
++++ b/src/main/java/org/bukkit/inventory/Inventory.java
+@@ -351,6 +351,17 @@ public interface Inventory extends Iterable<ItemStack> {
+      */
+     public String getTitle();
+ 
++    // PandaSpigot start - Adventure
++    /**
++     * Returns the title of this inventory.
++     *
++     * @return A String with the title.
++     */
++    default net.kyori.adventure.text.Component title() {
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(getTitle());
++    }
++    // PandaSpigot end
++
+     /**
+      * Returns what type of inventory this is.
+      *
+diff --git a/src/main/java/org/bukkit/inventory/InventoryView.java b/src/main/java/org/bukkit/inventory/InventoryView.java
+index 46242f8a219c3c9a2cbfb71c71af32100723365e..0e7f7beec449d36b0cceb68d84d8a1cff9d636d6 100644
+--- a/src/main/java/org/bukkit/inventory/InventoryView.java
++++ b/src/main/java/org/bukkit/inventory/InventoryView.java
+@@ -229,4 +229,13 @@ public abstract class InventoryView {
+     public final String getTitle() {
+         return getTopInventory().getTitle();
+     }
++
++    /**
++     * Get the title of this inventory window.
++     *
++     * @return The title.
++     */
++    public final net.kyori.adventure.text.Component title() {
++        return getTopInventory().title();
++    }
+ }
+diff --git a/src/main/java/org/bukkit/inventory/meta/BookMeta.java b/src/main/java/org/bukkit/inventory/meta/BookMeta.java
+index 00175963005cebabf758ed9b4aee6d77dd03e908..56d247be3b6a6f3e47dbc1bef6883c31b0a4adb9 100644
+--- a/src/main/java/org/bukkit/inventory/meta/BookMeta.java
++++ b/src/main/java/org/bukkit/inventory/meta/BookMeta.java
+@@ -8,7 +8,7 @@ import org.bukkit.Material;
+  * Represents a book ({@link Material#BOOK_AND_QUILL} or {@link
+  * Material#WRITTEN_BOOK}) that can have a title, an author, and pages.
+  */
+-public interface BookMeta extends ItemMeta {
++public interface BookMeta extends ItemMeta, net.kyori.adventure.inventory.Book { // PandaSpigot - Adventure
+ 
+     /**
+      * Checks for the existence of a title in the book.
+@@ -111,6 +111,30 @@ public interface BookMeta extends ItemMeta {
+      */
+     void setPages(String... pages);
+ 
++    // PandaSpigot start - Adventure
++    @Override
++    default net.kyori.adventure.text.Component title() {
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(getTitle());
++    }
++
++    @Override
++    default net.kyori.adventure.inventory.Book title(net.kyori.adventure.text.Component title) {
++        setTitle(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(title));
++        return this;
++    }
++
++    @Override
++    default net.kyori.adventure.text.Component author() {
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(getAuthor());
++    }
++
++    @Override
++    default net.kyori.adventure.inventory.Book author(net.kyori.adventure.text.Component author) {
++        setAuthor(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(author));
++        return this;
++    }
++    // PandaSpigot end
++
+     /**
+      * Adds new pages to the end of the book. Up to a maximum of 50 pages with
+      * 256 characters per page.
+diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
+index d8cc8218d370db66c6c4aac96372c2c6e00ad5f6..a09862e1aa10db1ba812ee3dbc3e59b26733f56b 100644
+--- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
++++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
+@@ -65,6 +65,69 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable {
+      */
+     void setLore(List<String> lore);
+ 
++    // PandaSpigot start - Adventure
++    /**
++     * Gets the display name that is set.
++     * <p>
++     * Plugins should check that hasDisplayName() returns <code>true</code>
++     * before calling this method.
++     *
++     * @return the display name that is set
++     */
++    default net.kyori.adventure.text.Component displayName() {
++        if (getDisplayName() == null) {
++            return null;
++        }
++
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(getDisplayName());
++    }
++
++    /**
++     * Sets the display name.
++     *
++     * @param displayName the name to set
++     */
++    default void displayName(net.kyori.adventure.text.Component displayName) {
++        if (displayName == null) {
++            setDisplayName(null);
++            return;
++        }
++
++        setDisplayName(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(displayName));
++    }
++
++    /**
++     * Gets the lore that is set.
++     * <p>
++     * Plugins should check if hasLore() returns <code>true</code> before
++     * calling this method.
++     *
++     * @return a list of lore that is set
++     */
++    default List<net.kyori.adventure.text.Component> lore() {
++        if (getLore() == null) {
++            return null;
++        }
++
++        return getLore().stream().map(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection()::deserialize).collect(java.util.stream.Collectors.toList());
++    }
++
++    /**
++     * Sets the lore for this item.
++     * Removes lore when given null.
++     *
++     * @param lore the lore that will be set
++     */
++    default void lore(List<net.kyori.adventure.text.Component> lore) {
++        if (lore == null) {
++            setLore(null);
++            return;
++        }
++
++        setLore(lore.stream().map(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection()::serialize).collect(java.util.stream.Collectors.toList()));
++    }
++    // PandaSpigot end
++
+     /**
+      * Checks for the existence of any enchantments.
+      *
+diff --git a/src/main/java/org/bukkit/permissions/Permissible.java b/src/main/java/org/bukkit/permissions/Permissible.java
+index 5cd3cff0232765c52cd7d85896c374799b9ba081..c90f73e4b17336b12580c0994522b3b345c6d170 100644
+--- a/src/main/java/org/bukkit/permissions/Permissible.java
++++ b/src/main/java/org/bukkit/permissions/Permissible.java
+@@ -119,4 +119,34 @@ public interface Permissible extends ServerOperator {
+      * @return Set of currently effective permissions
+      */
+     public Set<PermissionAttachmentInfo> getEffectivePermissions();
++
++    // PandaSpigot start - Adventure
++    /**
++     * Checks if this object has a permission set and, if it is set, the value of the permission.
++     *
++     * @param permission the permission to check
++     * @return a tri-state of if the permission is set and, if it is set, it's value
++     */
++    default net.kyori.adventure.util.TriState permissionValue(Permission permission) {
++        if (this.isPermissionSet(permission)) {
++            return net.kyori.adventure.util.TriState.byBoolean(this.hasPermission(permission));
++        } else {
++            return net.kyori.adventure.util.TriState.NOT_SET;
++        }
++    }
++
++    /**
++     * Checks if this object has a permission set and, if it is set, the value of the permission.
++     *
++     * @param permission the permission to check
++     * @return a tri-state of if the permission is set and, if it is set, it's value
++     */
++    default net.kyori.adventure.util.TriState permissionValue(String permission) {
++        if (this.isPermissionSet(permission)) {
++            return net.kyori.adventure.util.TriState.byBoolean(this.hasPermission(permission));
++        } else {
++            return net.kyori.adventure.util.TriState.NOT_SET;
++        }
++    }
++    // PandaSpigot end
+ }
+diff --git a/src/main/java/org/bukkit/scoreboard/Objective.java b/src/main/java/org/bukkit/scoreboard/Objective.java
+index 321aac7912571cb5d29c10068e14d12e3b1c6e11..752301525c77d178494ae79d49be760dbe5a3521 100644
+--- a/src/main/java/org/bukkit/scoreboard/Objective.java
++++ b/src/main/java/org/bukkit/scoreboard/Objective.java
+@@ -36,6 +36,31 @@ public interface Objective {
+      */
+     void setDisplayName(String displayName) throws IllegalStateException, IllegalArgumentException;
+ 
++    // PandaSpigot start - Adventure
++    /**
++     * Gets the name displayed to players for this objective
++     *
++     * @return this objective's display name
++     * @throws IllegalStateException if this objective has been unregistered
++     */
++    default net.kyori.adventure.text.Component displayName() throws IllegalStateException {
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(getDisplayName());
++    };
++
++    /**
++     * Sets the name displayed to players for this objective.
++     *
++     * @param displayName Display name to set
++     * @throws IllegalStateException if this objective has been unregistered
++     * @throws IllegalArgumentException if displayName is null
++     * @throws IllegalArgumentException if displayName is longer than 32
++     *     characters.
++     */
++    default void displayName(net.kyori.adventure.text.Component displayName) throws IllegalStateException {
++        setDisplayName(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(displayName));
++    }
++    // PandaSpigot end
++
+     /**
+      * Gets the criteria this objective tracks.
+      *
+diff --git a/src/main/java/org/bukkit/scoreboard/Team.java b/src/main/java/org/bukkit/scoreboard/Team.java
+index 0fdcebd91b9e9dabf0f4a63b332005b95e2d9b14..2eaf0c90292bba1d16caf9cffeca52f4175e7a55 100644
+--- a/src/main/java/org/bukkit/scoreboard/Team.java
++++ b/src/main/java/org/bukkit/scoreboard/Team.java
+@@ -76,6 +76,76 @@ public interface Team {
+      */
+     void setSuffix(String suffix) throws IllegalStateException, IllegalArgumentException;
+ 
++    // PandaSpigot start - Adventure
++    /**
++     * Gets the name displayed to entries for this team
++     *
++     * @return Team display name
++     * @throws IllegalStateException if this team has been unregistered
++     */
++    default net.kyori.adventure.text.Component displayName() throws IllegalStateException {
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(getDisplayName());
++    }
++
++    /**
++     * Sets the name displayed to entries for this team
++     *
++     * @param displayName New display name
++     * @throws IllegalArgumentException if displayName is longer than 32
++     *     characters.
++     * @throws IllegalStateException if this team has been unregistered
++     */
++    default void displayName(net.kyori.adventure.text.Component displayName) throws IllegalStateException {
++        setDisplayName(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(displayName));
++    }
++
++    /**
++     * Gets the prefix prepended to the display of entries on this team.
++     *
++     * @return Team prefix
++     * @throws IllegalStateException if this team has been unregistered
++     */
++    default net.kyori.adventure.text.Component prefix() throws IllegalStateException {
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(getPrefix());
++    }
++
++    /**
++     * Sets the prefix prepended to the display of entries on this team.
++     *
++     * @param prefix New prefix
++     * @throws IllegalArgumentException if prefix is null
++     * @throws IllegalArgumentException if prefix is longer than 16
++     *     characters
++     * @throws IllegalStateException if this team has been unregistered
++     */
++    default void prefix(net.kyori.adventure.text.Component prefix) throws IllegalStateException {
++        setPrefix(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(prefix));
++    }
++
++    /**
++     * Gets the suffix appended to the display of entries on this team.
++     *
++     * @return the team's current suffix
++     * @throws IllegalStateException if this team has been unregistered
++     */
++    default net.kyori.adventure.text.Component suffix() throws IllegalStateException {
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(getSuffix());
++    }
++
++    /**
++     * Sets the suffix appended to the display of entries on this team.
++     *
++     * @param suffix the new suffix for this team.
++     * @throws IllegalArgumentException if suffix is null
++     * @throws IllegalArgumentException if suffix is longer than 16
++     *     characters
++     * @throws IllegalStateException if this team has been unregistered
++     */
++    default void suffix(net.kyori.adventure.text.Component suffix) throws IllegalStateException {
++        setSuffix(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(suffix));
++    }
++    // PandaSpigot end
++
+     /**
+      * Gets the team friendly fire state
+      *

--- a/patches/api/0027-Adventure-API.patch
+++ b/patches/api/0027-Adventure-API.patch
@@ -551,7 +551,7 @@ index 7fb08af407dcacfbe37222dfd66064ffc3dd6963..5b0cfaf76a6f2d178e9fd50ce6123955
       * Sets whether or not to display the mob's custom name client side. The
       * name will be displayed above the mob similarly to a player.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index ec6187582a696f5705390eac92a04a36511c3a6c..751f2f0f6b9fb4af753584c890555dfa92d74fa1 100644
+index ec6187582a696f5705390eac92a04a36511c3a6c..72b84b584a65b4a26d856ab48272cc711de098dd 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -26,7 +26,7 @@ import org.github.paperspigot.Title;
@@ -640,30 +640,7 @@ index ec6187582a696f5705390eac92a04a36511c3a6c..751f2f0f6b9fb4af753584c890555dfa
      /**
       * Says a message (or runs a command).
       *
-@@ -364,6 +427,22 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
-      */
-     public void setPlayerListHeaderFooter(net.md_5.bungee.api.chat.BaseComponent header, net.md_5.bungee.api.chat.BaseComponent footer);
- 
-+    // PandaSpigot start - Adventure
-+    /**
-+     * Gets the currently displayed player list header for this player.
-+     *
-+     * @return player list header or null
-+     */
-+    public net.kyori.adventure.text.Component playerListHeader();
-+
-+    /**
-+     * Gets the current displayed player list footer for this player.
-+     *
-+     * @return player list footer or null
-+     */
-+    public net.kyori.adventure.text.Component playerListFooter();
-+    // PandaSpigot end
-+
-     /**
-      * Update the times for titles displayed to the player
-      *
-@@ -1362,4 +1441,11 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
+@@ -1362,4 +1425,11 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
  
      Spigot spigot();
      // Spigot end

--- a/patches/api/0027-Adventure-API.patch
+++ b/patches/api/0027-Adventure-API.patch
@@ -1171,7 +1171,7 @@ index 39e81b67840eadf4f41aab8a8eb4549f9f7043fa..f13bbbaaba286fe436a497dab7755b88
      @Override
      public HandlerList getHandlers() {
 diff --git a/src/main/java/org/bukkit/event/player/PlayerLocaleChangeEvent.java b/src/main/java/org/bukkit/event/player/PlayerLocaleChangeEvent.java
-index 3efd15972e79afebce3d30a24b7dabdf8b963d7c..f856c68a4de9dd6d88673a87e5db3758e1f0444c 100644
+index 3efd15972e79afebce3d30a24b7dabdf8b963d7c..53ff5b655b981ae6e8d4702af05166e13439fc90 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerLocaleChangeEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerLocaleChangeEvent.java
 @@ -10,11 +10,16 @@ public class PlayerLocaleChangeEvent extends PlayerEvent {
@@ -1218,13 +1218,6 @@ index 3efd15972e79afebce3d30a24b7dabdf8b963d7c..f856c68a4de9dd6d88673a87e5db3758
      @Override
      public HandlerList getHandlers() {
          return handlers;
-@@ -43,4 +68,4 @@ public class PlayerLocaleChangeEvent extends PlayerEvent {
-     public static HandlerList getHandlerList() {
-         return handlers;
-     }
--}
-\ No newline at end of file
-+}
 diff --git a/src/main/java/org/bukkit/event/player/PlayerLoginEvent.java b/src/main/java/org/bukkit/event/player/PlayerLoginEvent.java
 index 4bc024ffd3f94c161dd9f64ad5c6201c495e08fa..e9a4a227850329ba52f58a99bb9886ab7c04149d 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerLoginEvent.java

--- a/patches/api/0027-Adventure-API.patch
+++ b/patches/api/0027-Adventure-API.patch
@@ -676,10 +676,10 @@ index ec6187582a696f5705390eac92a04a36511c3a6c..751f2f0f6b9fb4af753584c890555dfa
 +    // PandaSpigot end
  }
 diff --git a/src/main/java/org/bukkit/event/block/SignChangeEvent.java b/src/main/java/org/bukkit/event/block/SignChangeEvent.java
-index 83188cf583695c55708c49b2596bc030ef9e8322..634ade9e9e74072f746263438b56105f52ec488f 100644
+index 83188cf583695c55708c49b2596bc030ef9e8322..a060ea07c2ccf4bfb801ca877009acccd0db6423 100644
 --- a/src/main/java/org/bukkit/event/block/SignChangeEvent.java
 +++ b/src/main/java/org/bukkit/event/block/SignChangeEvent.java
-@@ -14,13 +14,26 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
+@@ -14,9 +14,20 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
      private static final HandlerList handlers = new HandlerList();
      private boolean cancel = false;
      private final Player player;
@@ -687,27 +687,21 @@ index 83188cf583695c55708c49b2596bc030ef9e8322..634ade9e9e74072f746263438b56105f
 +    private final net.kyori.adventure.text.Component[] lines; // PandaSpigot - Adventure
  
      public SignChangeEvent(final Block theBlock, final Player thePlayer, final String[] theLines) {
++    // PandaSpigot start - Adventure
 +        super(theBlock);
 +        this.player = thePlayer;
-+        // PandaSpigot start - Adventure
 +        this.lines = new net.kyori.adventure.text.Component[theLines.length];
 +        for (int i = 0; i < theLines.length; i++) {
 +            this.lines[i] = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(theLines[i]);
 +        }
-+        // PandaSpigot end
 +    }
 +
-+    // PandaSpigot start - Adventure
 +    public SignChangeEvent(final Block theBlock, final Player thePlayer, final net.kyori.adventure.text.Component[] theLines) {
++    // PandaSpigot end
          super(theBlock);
          this.player = thePlayer;
          this.lines = theLines;
-     }
-+    // PandaSpigot end
- 
-     /**
-      * Gets the player changing the sign involved in this event.
-@@ -37,7 +50,7 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
+@@ -37,7 +48,7 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
       * @return the String array for the sign's lines new text
       */
      public String[] getLines() {
@@ -716,7 +710,7 @@ index 83188cf583695c55708c49b2596bc030ef9e8322..634ade9e9e74072f746263438b56105f
      }
  
      /**
-@@ -50,7 +63,7 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
+@@ -50,7 +61,7 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
       *     or < 0}
       */
      public String getLine(int index) throws IndexOutOfBoundsException {
@@ -725,14 +719,14 @@ index 83188cf583695c55708c49b2596bc030ef9e8322..634ade9e9e74072f746263438b56105f
      }
  
      /**
-@@ -62,8 +75,44 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
+@@ -62,6 +73,42 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
       *     or < 0}
       */
      public void setLine(int index, String line) throws IndexOutOfBoundsException {
-+        lines[index] = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(line); // PandaSpigot - Adventure
++    // PandaSpigot start - Adventure
++        lines[index] = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(line);
 +    }
 +
-+    // PandaSpigot start - Adventure
 +    /**
 +     * Gets all the lines of text from the sign involved in this event.
 +     *
@@ -764,14 +758,12 @@ index 83188cf583695c55708c49b2596bc030ef9e8322..634ade9e9e74072f746263438b56105f
 +     *     or < 0}
 +     */
 +    public void line(int index, net.kyori.adventure.text.Component line) throws IndexOutOfBoundsException {
++    // PandaSpigot end
          lines[index] = line;
      }
-+    // PandaSpigot end
  
-     public boolean isCancelled() {
-         return cancel;
 diff --git a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
-index aad03549523391d22e574778250f8169bbac33f6..de569c5eaeeb7de954017b7b4e80f4a89739e1bf 100644
+index aad03549523391d22e574778250f8169bbac33f6..b18ba658559072b142622544e2469d009b9c649b 100644
 --- a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
 +++ b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
 @@ -10,7 +10,7 @@ import org.bukkit.inventory.ItemStack;
@@ -783,18 +775,18 @@ index aad03549523391d22e574778250f8169bbac33f6..de569c5eaeeb7de954017b7b4e80f4a8
      private int newLevel = 0;
      private int newTotalExp = 0;
      private boolean keepLevel = false;
-@@ -25,12 +25,30 @@ public class PlayerDeathEvent extends EntityDeathEvent {
+@@ -25,6 +25,24 @@ public class PlayerDeathEvent extends EntityDeathEvent {
      }
  
      public PlayerDeathEvent(final Player player, final List<ItemStack> drops, final int droppedExp, final int newExp, final int newTotalExp, final int newLevel, final String deathMessage) {
++    // PandaSpigot start - Adventure
 +        super(player, drops, droppedExp);
 +        this.newExp = newExp;
 +        this.newTotalExp = newTotalExp;
 +        this.newLevel = newLevel;
-+        this.deathMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(deathMessage); // PandaSpigot - Adventure
++        this.deathMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(deathMessage);
 +    }
 +
-+    // PandaSpigot start - Adventure
 +    public PlayerDeathEvent(final Player player, final List<ItemStack> drops, final int droppedExp, final net.kyori.adventure.text.Component deathMessage) {
 +        this(player, drops, droppedExp, 0, deathMessage);
 +    }
@@ -804,16 +796,10 @@ index aad03549523391d22e574778250f8169bbac33f6..de569c5eaeeb7de954017b7b4e80f4a8
 +    }
 +
 +    public PlayerDeathEvent(final Player player, final List<ItemStack> drops, final int droppedExp, final int newExp, final int newTotalExp, final int newLevel, final net.kyori.adventure.text.Component deathMessage) {
++     // PandaSpigot end
          super(player, drops, droppedExp);
          this.newExp = newExp;
          this.newTotalExp = newTotalExp;
-         this.newLevel = newLevel;
-         this.deathMessage = deathMessage;
-     }
-+    // PandaSpigot end
- 
-     @Override
-     public Player getEntity() {
 @@ -43,7 +61,7 @@ public class PlayerDeathEvent extends EntityDeathEvent {
       * @param deathMessage Message to appear to other players on the server.
       */
@@ -823,14 +809,14 @@ index aad03549523391d22e574778250f8169bbac33f6..de569c5eaeeb7de954017b7b4e80f4a8
      }
  
      /**
-@@ -52,8 +70,28 @@ public class PlayerDeathEvent extends EntityDeathEvent {
+@@ -52,6 +70,26 @@ public class PlayerDeathEvent extends EntityDeathEvent {
       * @return Message to appear to other players on the server.
       */
      public String getDeathMessage() {
-+        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serializeOrNull(deathMessage); // PandaSpigot - Adventure
++    // PandaSpigot start - Adventure
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serializeOrNull(deathMessage);
 +    }
 +
-+    // PandaSpigot start - Adventure
 +    /**
 +     * Set the death message that will appear to everyone on the server.
 +     *
@@ -846,12 +832,10 @@ index aad03549523391d22e574778250f8169bbac33f6..de569c5eaeeb7de954017b7b4e80f4a8
 +     * @return Message to appear to other players on the server.
 +     */
 +    public net.kyori.adventure.text.Component deathMessage() {
++    // PandaSpigot end
          return deathMessage;
      }
-+    // PandaSpigot end
  
-     /**
-      * Gets how much EXP the Player should have at respawn.
 diff --git a/src/main/java/org/bukkit/event/inventory/InventoryType.java b/src/main/java/org/bukkit/event/inventory/InventoryType.java
 index c36e0467281fef62c8362640df1b9e4990562d47..db080e2907b61dbd407e10351a751ac0fd5813a1 100644
 --- a/src/main/java/org/bukkit/event/inventory/InventoryType.java
@@ -998,10 +982,10 @@ index 62562d3503d856a3dce22c3e972543f1a2d63cca..076c6e83ff7fa4fb55c09da8263a46c7
       * Gets the player's name.
       *
 diff --git a/src/main/java/org/bukkit/event/player/PlayerJoinEvent.java b/src/main/java/org/bukkit/event/player/PlayerJoinEvent.java
-index e7481f92c758396ea2035d404042d5fd8193def0..5ea0f4a9a9d320cb78af81d51abe058ff783983e 100644
+index e7481f92c758396ea2035d404042d5fd8193def0..6cee8370285487ce691bb38dfaa09c5e1dffc74a 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerJoinEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerJoinEvent.java
-@@ -8,12 +8,19 @@ import org.bukkit.event.HandlerList;
+@@ -8,9 +8,16 @@ import org.bukkit.event.HandlerList;
   */
  public class PlayerJoinEvent extends PlayerEvent {
      private static final HandlerList handlers = new HandlerList();
@@ -1009,19 +993,16 @@ index e7481f92c758396ea2035d404042d5fd8193def0..5ea0f4a9a9d320cb78af81d51abe058f
 +    private net.kyori.adventure.text.Component joinMessage; // PandaSpigot - Adventure
  
      public PlayerJoinEvent(final Player playerJoined, final String joinMessage) {
++    // PandaSpigot start - Adventure
 +        super(playerJoined);
-+        this.joinMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(joinMessage); // PandaSpigot - Adventure
++        this.joinMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(joinMessage);
 +    }
 +
-+    // PandaSpigot start - Adventure
 +    public PlayerJoinEvent(final Player playerJoined, final net.kyori.adventure.text.Component joinMessage) {
++    // PandaSpigot end
          super(playerJoined);
          this.joinMessage = joinMessage;
      }
-+    // PandaSpigot end
- 
-     /**
-      * Gets the join message to send to all online players
 @@ -21,7 +28,7 @@ public class PlayerJoinEvent extends PlayerEvent {
       * @return string join message
       */
@@ -1031,14 +1012,14 @@ index e7481f92c758396ea2035d404042d5fd8193def0..5ea0f4a9a9d320cb78af81d51abe058f
      }
  
      /**
-@@ -30,8 +37,28 @@ public class PlayerJoinEvent extends PlayerEvent {
+@@ -30,6 +37,26 @@ public class PlayerJoinEvent extends PlayerEvent {
       * @param joinMessage join message
       */
      public void setJoinMessage(String joinMessage) {
-+        this.joinMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserializeOrNull(joinMessage); // PandaSpigot - Adventure
++    // PandaSpigot start - Adventure
++        this.joinMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserializeOrNull(joinMessage);
 +    }
 +
-+    // PandaSpigot start - Adventure
 +    /**
 +     * Gets the join message to send to all online players
 +     *
@@ -1054,17 +1035,15 @@ index e7481f92c758396ea2035d404042d5fd8193def0..5ea0f4a9a9d320cb78af81d51abe058f
 +     * @param joinMessage join message
 +     */
 +    public void joinMessage(net.kyori.adventure.text.Component joinMessage) {
++    // PandaSpigot end
          this.joinMessage = joinMessage;
      }
-+    // PandaSpigot end
  
-     @Override
-     public HandlerList getHandlers() {
 diff --git a/src/main/java/org/bukkit/event/player/PlayerKickEvent.java b/src/main/java/org/bukkit/event/player/PlayerKickEvent.java
-index 39e81b67840eadf4f41aab8a8eb4549f9f7043fa..f13bbbaaba286fe436a497dab7755b8819b622af 100644
+index 39e81b67840eadf4f41aab8a8eb4549f9f7043fa..88955dcc529a938745787e80187e4cd855cb9e91 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerKickEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerKickEvent.java
-@@ -9,16 +9,29 @@ import org.bukkit.event.HandlerList;
+@@ -9,11 +9,22 @@ import org.bukkit.event.HandlerList;
   */
  public class PlayerKickEvent extends PlayerEvent implements Cancellable {
      private static final HandlerList handlers = new HandlerList();
@@ -1077,57 +1056,50 @@ index 39e81b67840eadf4f41aab8a8eb4549f9f7043fa..f13bbbaaba286fe436a497dab7755b88
      private Boolean cancel;
  
      public PlayerKickEvent(final Player playerKicked, final String kickReason, final String leaveMessage) {
-+        super(playerKicked);
 +        // PandaSpigot start - Adventure
++        super(playerKicked);
 +        this.kickReason = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(kickReason);
 +        this.leaveMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(leaveMessage);
-+        // PandaSpigot end
 +        this.cancel = false;
 +    }
 +
-+    // PandaSpigot start - Adventure
 +    public PlayerKickEvent(final Player playerKicked, final net.kyori.adventure.text.Component kickReason, final net.kyori.adventure.text.Component leaveMessage) {
++        // PandaSpigot end
          super(playerKicked);
          this.kickReason = kickReason;
          this.leaveMessage = leaveMessage;
-         this.cancel = false;
-     }
-+    // PandaSpigot end
- 
-     /**
-      * Gets the reason why the player is getting kicked
-@@ -26,7 +39,7 @@ public class PlayerKickEvent extends PlayerEvent implements Cancellable {
+@@ -26,7 +37,7 @@ public class PlayerKickEvent extends PlayerEvent implements Cancellable {
       * @return string kick reason
       */
      public String getReason() {
 -        return kickReason;
-+        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(kickReason);
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(kickReason); // PandaSpigot - Adventure
      }
  
      /**
-@@ -35,7 +48,7 @@ public class PlayerKickEvent extends PlayerEvent implements Cancellable {
+@@ -35,7 +46,7 @@ public class PlayerKickEvent extends PlayerEvent implements Cancellable {
       * @return string kick reason
       */
      public String getLeaveMessage() {
 -        return leaveMessage;
-+        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serializeOrNull(leaveMessage);
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serializeOrNull(leaveMessage); // PandaSpigot - Adventure
      }
  
      public boolean isCancelled() {
-@@ -52,7 +65,7 @@ public class PlayerKickEvent extends PlayerEvent implements Cancellable {
+@@ -52,7 +63,7 @@ public class PlayerKickEvent extends PlayerEvent implements Cancellable {
       * @param kickReason kick reason
       */
      public void setReason(String kickReason) {
 -        this.kickReason = kickReason;
-+        this.kickReason = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(kickReason);
++        this.kickReason = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(kickReason); // PandaSpigot - Adventure
      }
  
      /**
-@@ -61,8 +74,46 @@ public class PlayerKickEvent extends PlayerEvent implements Cancellable {
+@@ -61,6 +72,44 @@ public class PlayerKickEvent extends PlayerEvent implements Cancellable {
       * @param leaveMessage leave message
       */
      public void setLeaveMessage(String leaveMessage) {
-+        this.leaveMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserializeOrNull(leaveMessage);
++        this.leaveMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserializeOrNull(leaveMessage); // PandaSpigot - Adventure
 +    }
 +
 +    // PandaSpigot start - Adventure
@@ -1164,12 +1136,10 @@ index 39e81b67840eadf4f41aab8a8eb4549f9f7043fa..f13bbbaaba286fe436a497dab7755b88
 +     * @param leaveMessage leave message
 +     */
 +    public void leaveMessage(net.kyori.adventure.text.Component leaveMessage) {
++    // PandaSpigot end
          this.leaveMessage = leaveMessage;
      }
-+    // PandaSpigot end
  
-     @Override
-     public HandlerList getHandlers() {
 diff --git a/src/main/java/org/bukkit/event/player/PlayerLocaleChangeEvent.java b/src/main/java/org/bukkit/event/player/PlayerLocaleChangeEvent.java
 index 3efd15972e79afebce3d30a24b7dabdf8b963d7c..53ff5b655b981ae6e8d4702af05166e13439fc90 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerLocaleChangeEvent.java
@@ -1219,7 +1189,7 @@ index 3efd15972e79afebce3d30a24b7dabdf8b963d7c..53ff5b655b981ae6e8d4702af05166e1
      public HandlerList getHandlers() {
          return handlers;
 diff --git a/src/main/java/org/bukkit/event/player/PlayerLoginEvent.java b/src/main/java/org/bukkit/event/player/PlayerLoginEvent.java
-index 4bc024ffd3f94c161dd9f64ad5c6201c495e08fa..e9a4a227850329ba52f58a99bb9886ab7c04149d 100644
+index 4bc024ffd3f94c161dd9f64ad5c6201c495e08fa..d83faca470ffe44c4dd5c7610e1acb2c4087db20 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerLoginEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerLoginEvent.java
 @@ -13,7 +13,7 @@ public class PlayerLoginEvent extends PlayerEvent {
@@ -1235,10 +1205,10 @@ index 4bc024ffd3f94c161dd9f64ad5c6201c495e08fa..e9a4a227850329ba52f58a99bb9886ab
      public PlayerLoginEvent(final Player player, String hostname, final InetAddress address, final Result result, final String message, final InetAddress realAddress) { // Spigot
          this(player, hostname, address, realAddress); // Spigot
          this.result = result;
++     // PandaSpigot start - Adventure
 +        this.message = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(message); // PandaSpigot - Adventure
 +    }
 +
-+    // PandaSpigot start - Adventure
 +    /**
 +     * This constructor pre-configures the event with a result and message
 +     *
@@ -1285,7 +1255,7 @@ index 4bc024ffd3f94c161dd9f64ad5c6201c495e08fa..e9a4a227850329ba52f58a99bb9886ab
      }
  
      /**
-@@ -158,9 +176,41 @@ public class PlayerLoginEvent extends PlayerEvent {
+@@ -158,6 +176,38 @@ public class PlayerLoginEvent extends PlayerEvent {
       * @param message Kick message to display to the user
       */
      public void disallow(final Result result, final String message) {
@@ -1320,15 +1290,12 @@ index 4bc024ffd3f94c161dd9f64ad5c6201c495e08fa..e9a4a227850329ba52f58a99bb9886ab
 +     * @param message Kick message to display to the user
 +     */
 +    public void disallow(final Result result, final net.kyori.adventure.text.Component message) {
++    // PandaSpigot end
          this.result = result;
          this.message = message;
      }
-+    // PandaSpigot end
- 
-     /**
-      * Gets the {@link InetAddress} for the Player associated with this event.
 diff --git a/src/main/java/org/bukkit/event/player/PlayerPreLoginEvent.java b/src/main/java/org/bukkit/event/player/PlayerPreLoginEvent.java
-index e8553f0f36b1b25bf44087f8d72fb81d8c8424e5..4686c71ee373cb63a1af994fc8a712c3160d7d81 100644
+index e8553f0f36b1b25bf44087f8d72fb81d8c8424e5..afce46f5481fb13e647addb34d68e9958051c585 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerPreLoginEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerPreLoginEvent.java
 @@ -19,7 +19,7 @@ import org.bukkit.event.HandlerList;
@@ -1376,15 +1343,15 @@ index e8553f0f36b1b25bf44087f8d72fb81d8c8424e5..4686c71ee373cb63a1af994fc8a712c3
      }
  
      /**
-@@ -89,9 +89,41 @@ public class PlayerPreLoginEvent extends Event {
+@@ -89,6 +89,38 @@ public class PlayerPreLoginEvent extends Event {
       * @param message Kick message to display to the user
       */
      public void disallow(final Result result, final String message) {
++        // PandaSpigot start - Adventure
 +        this.result = result;
-+        this.message = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(message); // PandaSpigot - Adventure
++        this.message = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(message);
 +    }
 +
-+    // PandaSpigot start - Adventure
 +    /**
 +     * Gets the current kick message that will be used if getResult() !=
 +     * Result.ALLOWED
@@ -1411,18 +1378,15 @@ index e8553f0f36b1b25bf44087f8d72fb81d8c8424e5..4686c71ee373cb63a1af994fc8a712c3
 +     * @param message Kick message to display to the user
 +     */
 +    public void disallow(final Result result, final net.kyori.adventure.text.Component message) {
++    // PandaSpigot end
          this.result = result;
          this.message = message;
      }
-+    // PandaSpigot end
- 
-     /**
-      * Gets the player's name.
 diff --git a/src/main/java/org/bukkit/event/player/PlayerQuitEvent.java b/src/main/java/org/bukkit/event/player/PlayerQuitEvent.java
-index 5c8dc1b91c297b40e05dcbabf48cc12d194b34eb..37cda58c37d075bf19dce548cf0341232af1d15e 100644
+index 5c8dc1b91c297b40e05dcbabf48cc12d194b34eb..84868a9144812ada41d7c69a2f291651eb9f684e 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerQuitEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerQuitEvent.java
-@@ -8,12 +8,19 @@ import org.bukkit.event.HandlerList;
+@@ -8,9 +8,16 @@ import org.bukkit.event.HandlerList;
   */
  public class PlayerQuitEvent extends PlayerEvent {
      private static final HandlerList handlers = new HandlerList();
@@ -1430,19 +1394,16 @@ index 5c8dc1b91c297b40e05dcbabf48cc12d194b34eb..37cda58c37d075bf19dce548cf034123
 +    private net.kyori.adventure.text.Component quitMessage; // PandaSpigot - Adventure
  
      public PlayerQuitEvent(final Player who, final String quitMessage) {
++    // PandaSpigot start - Adventure
 +        super(who);
-+        this.quitMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(quitMessage); // PandaSpigot - Adventure
++        this.quitMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(quitMessage);
 +    }
 +
-+    // PandaSpigot start - Adventure
 +    public PlayerQuitEvent(final Player who, final net.kyori.adventure.text.Component quitMessage) {
++    // PandaSpigot end
          super(who);
          this.quitMessage = quitMessage;
      }
-+    // PandaSpigot end
- 
-     /**
-      * Gets the quit message to send to all online players
 @@ -21,7 +28,7 @@ public class PlayerQuitEvent extends PlayerEvent {
       * @return string quit message
       */
@@ -1452,14 +1413,14 @@ index 5c8dc1b91c297b40e05dcbabf48cc12d194b34eb..37cda58c37d075bf19dce548cf034123
      }
  
      /**
-@@ -30,8 +37,28 @@ public class PlayerQuitEvent extends PlayerEvent {
+@@ -30,6 +37,26 @@ public class PlayerQuitEvent extends PlayerEvent {
       * @param quitMessage quit message
       */
      public void setQuitMessage(String quitMessage) {
-+        this.quitMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserializeOrNull(quitMessage); // PandaSpigot - Adventure
++    // PandaSpigot start - Adventure
++        this.quitMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserializeOrNull(quitMessage);
 +    }
 +
-+    // PandaSpigot start - Adventure
 +    /**
 +     * Gets the quit message to send to all online players
 +     *
@@ -1475,14 +1436,12 @@ index 5c8dc1b91c297b40e05dcbabf48cc12d194b34eb..37cda58c37d075bf19dce548cf034123
 +     * @param quitMessage quit message
 +     */
 +    public void quitMessage(net.kyori.adventure.text.Component quitMessage) {
++    // PandaSpigot end
          this.quitMessage = quitMessage;
      }
-+    // PandaSpigot end
  
-     @Override
-     public HandlerList getHandlers() {
 diff --git a/src/main/java/org/bukkit/event/server/ServerListPingEvent.java b/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
-index 3c38d85735d37b401061feae686dea50adb5b650..bcf68ca2bea489e7d39e90e4157f8cca5a150eda 100644
+index 3c38d85735d37b401061feae686dea50adb5b650..252917a66e29070e84ed9d2fcaa46169d7ff929c 100644
 --- a/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
 +++ b/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
 @@ -16,7 +16,7 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
@@ -1503,15 +1462,15 @@ index 3c38d85735d37b401061feae686dea50adb5b650..bcf68ca2bea489e7d39e90e4157f8cca
          this.numPlayers = numPlayers;
          this.maxPlayers = maxPlayers;
      }
-@@ -42,9 +42,37 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
+@@ -42,6 +42,34 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
          super(); // Paper - Is this event being fired async?
          this.numPlayers = MAGIC_PLAYER_COUNT;
          this.address = address;
-+        this.motd = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(motd); // PandaSpigot - Adventure
++    // PandaSpigot start - Adventure
++        this.motd = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(motd);
 +        this.maxPlayers = maxPlayers;
 +    }
 +
-+    // PandaSpigot start - Adventure
 +    public ServerListPingEvent(final InetAddress address, final net.kyori.adventure.text.Component motd, final int numPlayers, final int maxPlayers) {
 +        super();
 +        Validate.isTrue(numPlayers >= 0, "Cannot have negative number of players online", numPlayers);
@@ -1534,13 +1493,10 @@ index 3c38d85735d37b401061feae686dea50adb5b650..bcf68ca2bea489e7d39e90e4157f8cca
 +        super();
 +        this.numPlayers = MAGIC_PLAYER_COUNT;
 +        this.address = address;
++    // PandaSpigot end
          this.motd = motd;
          this.maxPlayers = maxPlayers;
      }
-+    // PandaSpigot end
- 
-     /**
-      * Get the address the ping is coming from.
 @@ -61,7 +89,7 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
       * @return the message of the day
       */
@@ -1550,14 +1506,14 @@ index 3c38d85735d37b401061feae686dea50adb5b650..bcf68ca2bea489e7d39e90e4157f8cca
      }
  
      /**
-@@ -70,8 +98,28 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
+@@ -70,6 +98,26 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
       * @param motd the message of the day
       */
      public void setMotd(String motd) {
-+        this.motd = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(motd); // PandaSpigot - Adventure
++    // PandaSpigot start - Adventure
++        this.motd = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(motd);
 +    }
 +
-+    // PandaSpigot start - Adventure
 +    /**
 +     * Get the message of the day message.
 +     *
@@ -1573,12 +1529,10 @@ index 3c38d85735d37b401061feae686dea50adb5b650..bcf68ca2bea489e7d39e90e4157f8cca
 +     * @param motd the message of the day
 +     */
 +    public void motd(net.kyori.adventure.text.Component motd) {
++    // PandaSpigot end
          this.motd = motd;
      }
-+    // PandaSpigot end
  
-     /**
-      * Get the number of players sent.
 diff --git a/src/main/java/org/bukkit/inventory/Inventory.java b/src/main/java/org/bukkit/inventory/Inventory.java
 index da5d83e021d3dacd1032750432bb02658170260d..60155118eeda28f78379e3809b2c25851abae84e 100644
 --- a/src/main/java/org/bukkit/inventory/Inventory.java
@@ -1602,14 +1556,15 @@ index da5d83e021d3dacd1032750432bb02658170260d..60155118eeda28f78379e3809b2c2585
       * Returns what type of inventory this is.
       *
 diff --git a/src/main/java/org/bukkit/inventory/InventoryView.java b/src/main/java/org/bukkit/inventory/InventoryView.java
-index 46242f8a219c3c9a2cbfb71c71af32100723365e..0e7f7beec449d36b0cceb68d84d8a1cff9d636d6 100644
+index 46242f8a219c3c9a2cbfb71c71af32100723365e..c1235f11f9139898265eb39bc8dbed88b5c6e707 100644
 --- a/src/main/java/org/bukkit/inventory/InventoryView.java
 +++ b/src/main/java/org/bukkit/inventory/InventoryView.java
-@@ -229,4 +229,13 @@ public abstract class InventoryView {
+@@ -229,4 +229,15 @@ public abstract class InventoryView {
      public final String getTitle() {
          return getTopInventory().getTitle();
      }
 +
++    // PandaSpigot start - Adventure
 +    /**
 +     * Get the title of this inventory window.
 +     *
@@ -1618,6 +1573,7 @@ index 46242f8a219c3c9a2cbfb71c71af32100723365e..0e7f7beec449d36b0cceb68d84d8a1cf
 +    public final net.kyori.adventure.text.Component title() {
 +        return getTopInventory().title();
 +    }
++    // PandaSpigot end
  }
 diff --git a/src/main/java/org/bukkit/inventory/meta/BookMeta.java b/src/main/java/org/bukkit/inventory/meta/BookMeta.java
 index 00175963005cebabf758ed9b4aee6d77dd03e908..56d247be3b6a6f3e47dbc1bef6883c31b0a4adb9 100644

--- a/patches/api/0027-Adventure-API.patch
+++ b/patches/api/0027-Adventure-API.patch
@@ -867,7 +867,7 @@ index c36e0467281fef62c8362640df1b9e4990562d47..db080e2907b61dbd407e10351a751ac0
          /**
           * A result slot in a furnace or crafting inventory.
 diff --git a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
-index 62562d3503d856a3dce22c3e972543f1a2d63cca..076c6e83ff7fa4fb55c09da8263a46c7597101b7 100644
+index 62562d3503d856a3dce22c3e972543f1a2d63cca..202443301038cfe95bded5e5c85aa9e030e64cf2 100644
 --- a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
 +++ b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
 @@ -14,7 +14,7 @@ import org.bukkit.event.HandlerList;
@@ -928,10 +928,10 @@ index 62562d3503d856a3dce22c3e972543f1a2d63cca..076c6e83ff7fa4fb55c09da8263a46c7
      @Deprecated
      public void disallow(final PlayerPreLoginEvent.Result result, final String message) {
          this.result = result == null ? null : Result.valueOf(result.name());
-+        this.message = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(message); // PandaSpigot - Adventure
++    // PandaSpigot start - Adventure
++        this.message = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(message);
 +    }
 +
-+    // PandaSpigot start - Adventure
 +    /**
 +     * Gets the current kick message that will be used if getResult() !=
 +     * Result.ALLOWED
@@ -1040,7 +1040,7 @@ index e7481f92c758396ea2035d404042d5fd8193def0..6cee8370285487ce691bb38dfaa09c5e
      }
  
 diff --git a/src/main/java/org/bukkit/event/player/PlayerKickEvent.java b/src/main/java/org/bukkit/event/player/PlayerKickEvent.java
-index 39e81b67840eadf4f41aab8a8eb4549f9f7043fa..88955dcc529a938745787e80187e4cd855cb9e91 100644
+index 39e81b67840eadf4f41aab8a8eb4549f9f7043fa..6aa7b904353194f177282d5fe16462ac0ea9fafd 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerKickEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerKickEvent.java
 @@ -9,11 +9,22 @@ import org.bukkit.event.HandlerList;
@@ -1099,10 +1099,10 @@ index 39e81b67840eadf4f41aab8a8eb4549f9f7043fa..88955dcc529a938745787e80187e4cd8
       * @param leaveMessage leave message
       */
      public void setLeaveMessage(String leaveMessage) {
-+        this.leaveMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserializeOrNull(leaveMessage); // PandaSpigot - Adventure
++    // PandaSpigot start - Adventure
++        this.leaveMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserializeOrNull(leaveMessage);
 +    }
 +
-+    // PandaSpigot start - Adventure
 +    /**
 +     * Gets the reason why the player is getting kicked
 +     *
@@ -1189,7 +1189,7 @@ index 3efd15972e79afebce3d30a24b7dabdf8b963d7c..53ff5b655b981ae6e8d4702af05166e1
      public HandlerList getHandlers() {
          return handlers;
 diff --git a/src/main/java/org/bukkit/event/player/PlayerLoginEvent.java b/src/main/java/org/bukkit/event/player/PlayerLoginEvent.java
-index 4bc024ffd3f94c161dd9f64ad5c6201c495e08fa..d83faca470ffe44c4dd5c7610e1acb2c4087db20 100644
+index 4bc024ffd3f94c161dd9f64ad5c6201c495e08fa..1ecabb0c6c1c306324230c7ac61be5b042b35476 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerLoginEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerLoginEvent.java
 @@ -13,7 +13,7 @@ public class PlayerLoginEvent extends PlayerEvent {
@@ -1201,7 +1201,7 @@ index 4bc024ffd3f94c161dd9f64ad5c6201c495e08fa..d83faca470ffe44c4dd5c7610e1acb2c
      private final InetAddress realAddress; // Spigot
  
      /**
-@@ -82,8 +82,26 @@ public class PlayerLoginEvent extends PlayerEvent {
+@@ -82,6 +82,24 @@ public class PlayerLoginEvent extends PlayerEvent {
      public PlayerLoginEvent(final Player player, String hostname, final InetAddress address, final Result result, final String message, final InetAddress realAddress) { // Spigot
          this(player, hostname, address, realAddress); // Spigot
          this.result = result;
@@ -1222,12 +1222,10 @@ index 4bc024ffd3f94c161dd9f64ad5c6201c495e08fa..d83faca470ffe44c4dd5c7610e1acb2c
 +    public PlayerLoginEvent(final Player player, String hostname, final InetAddress address, final Result result, final net.kyori.adventure.text.Component message, final InetAddress realAddress) {
 +        this(player, hostname, address, realAddress);
 +        this.result = result;
++    // PandaSpigot end
          this.message = message;
      }
-+    // PandaSpigot end
  
-     // Spigot start
-     /**
 @@ -121,7 +139,7 @@ public class PlayerLoginEvent extends PlayerEvent {
       * @return Current kick message
       */
@@ -1259,11 +1257,11 @@ index 4bc024ffd3f94c161dd9f64ad5c6201c495e08fa..d83faca470ffe44c4dd5c7610e1acb2c
       * @param message Kick message to display to the user
       */
      public void disallow(final Result result, final String message) {
++    // PandaSpigot start - Adventure
 +        this.result = result;
-+        this.message = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(message); // PandaSpigot - Adventure
++        this.message = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(message);
 +    }
 +
-+    // PandaSpigot start - Adventure
 +    /**
 +     * Gets the current kick message that will be used if getResult() !=
 +     * Result.ALLOWED

--- a/patches/server/0114-Adventure-API.patch
+++ b/patches/server/0114-Adventure-API.patch
@@ -257,7 +257,7 @@ index b4f301a3eb660b9bf080c4f6b4e3bbaa3678a8d6..d981c89fd182bae75c928616edc5944f
          // we clean the player's inventory after the EntityDeathEvent is called so plugins can get the exact state of the inventory.
          if (!event.getKeepInventory()) {
 diff --git a/src/main/java/net/minecraft/server/LoginListener.java b/src/main/java/net/minecraft/server/LoginListener.java
-index 9faa98501275cbd03a34dcc83f281d1e3f40a6e0..5d50379171901bd9cd0fce6b379deeadb00598aa 100644
+index 9faa98501275cbd03a34dcc83f281d1e3f40a6e0..fe5dcad624982134cf4f7c4e651be457b3073218 100644
 --- a/src/main/java/net/minecraft/server/LoginListener.java
 +++ b/src/main/java/net/minecraft/server/LoginListener.java
 @@ -75,17 +75,20 @@ public class LoginListener implements PacketLoginInListener, IUpdatePlayerListBo
@@ -287,6 +287,15 @@ index 9faa98501275cbd03a34dcc83f281d1e3f40a6e0..5d50379171901bd9cd0fce6b379deead
  
      // Spigot start
      public void initUUID()
+@@ -267,7 +270,7 @@ public class LoginListener implements PacketLoginInListener, IUpdatePlayerListBo
+                             if (PlayerPreLoginEvent.getHandlerList().getRegisteredListeners().length != 0) {
+                                 final PlayerPreLoginEvent event = new PlayerPreLoginEvent(playerName, address, uniqueId);
+                                 if (asyncEvent.getResult() != PlayerPreLoginEvent.Result.ALLOWED) {
+-                                    event.disallow(asyncEvent.getResult(), asyncEvent.getKickMessage());
++                                    event.disallow(asyncEvent.getResult(), event.kickMessage()); // PandaSpigot - Adventure
+                                 }
+                                 Waitable<PlayerPreLoginEvent.Result> waitable = new Waitable<PlayerPreLoginEvent.Result>() {
+                                     @Override
 @@ -278,12 +281,12 @@ public class LoginListener implements PacketLoginInListener, IUpdatePlayerListBo
  
                                  LoginListener.this.server.processQueue.add(waitable);

--- a/patches/server/0114-Adventure-API.patch
+++ b/patches/server/0114-Adventure-API.patch
@@ -257,36 +257,30 @@ index b4f301a3eb660b9bf080c4f6b4e3bbaa3678a8d6..d981c89fd182bae75c928616edc5944f
          // we clean the player's inventory after the EntityDeathEvent is called so plugins can get the exact state of the inventory.
          if (!event.getKeepInventory()) {
 diff --git a/src/main/java/net/minecraft/server/LoginListener.java b/src/main/java/net/minecraft/server/LoginListener.java
-index 9faa98501275cbd03a34dcc83f281d1e3f40a6e0..fe5dcad624982134cf4f7c4e651be457b3073218 100644
+index 9faa98501275cbd03a34dcc83f281d1e3f40a6e0..8d2a07782d370d3cdd8d26790a17c88498b8d258 100644
 --- a/src/main/java/net/minecraft/server/LoginListener.java
 +++ b/src/main/java/net/minecraft/server/LoginListener.java
-@@ -75,17 +75,20 @@ public class LoginListener implements PacketLoginInListener, IUpdatePlayerListBo
+@@ -75,12 +75,15 @@ public class LoginListener implements PacketLoginInListener, IUpdatePlayerListBo
      }
  
      public void disconnect(String s) {
--        try {
++        // PandaSpigot start - Adventure
++        disconnect(new ChatComponentText(s));
++    }
++    public void disconnect(IChatBaseComponent ichatbasecomponent) {
+         try {
 -            LoginListener.c.info("Disconnecting " + this.d() + ": " + s);
 -            ChatComponentText chatcomponenttext = new ChatComponentText(s);
-+        disconnect(new ChatComponentText(s)); // PandaSpigot - Adventure
-+    }
- 
+-
 -            this.networkManager.handle(new PacketLoginOutDisconnect(chatcomponenttext));
 -            this.networkManager.close(chatcomponenttext);
-+    // PandaSpigot start - Adventure
-+    public void disconnect(IChatBaseComponent ichatbasecomponent) {
-+        try {
 +            LoginListener.c.info("Disconnecting {}: {}", this.d(), ichatbasecomponent.getText());
 +            this.networkManager.handle(new PacketLoginOutDisconnect(ichatbasecomponent));
 +            this.networkManager.close(ichatbasecomponent);
++        // PandaSpigot end
          } catch (Exception exception) {
              LoginListener.c.error("Error whilst disconnecting player", exception);
          }
--
-     }
-+    // PandaSpigot end
- 
-     // Spigot start
-     public void initUUID()
 @@ -267,7 +270,7 @@ public class LoginListener implements PacketLoginInListener, IUpdatePlayerListBo
                              if (PlayerPreLoginEvent.getHandlerList().getRegisteredListeners().length != 0) {
                                  final PlayerPreLoginEvent event = new PlayerPreLoginEvent(playerName, address, uniqueId);

--- a/patches/server/0114-Adventure-API.patch
+++ b/patches/server/0114-Adventure-API.patch
@@ -642,18 +642,10 @@ index 43adfccd72c0629f5b93c735119fa4f84074d12b..5f39a8dff50d59cea70d6050f4e17101
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 49477a0f4d237db75d869ed91dc5088f4b4385fe..6d2357123c716f5f43d7f0f08fc96addde2f5342 100644
+index 49477a0f4d237db75d869ed91dc5088f4b4385fe..a6c17a3fd08609eb427aaae8dcaced3f12e7837d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -80,6 +80,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
-     private double health = 20;
-     private boolean scaledHealth = false;
-     private double healthScale = 20;
-+    private net.kyori.adventure.text.Component playerListHeader, playerListFooter; // PandaSpigot - Adventure
- 
-     public CraftPlayer(CraftServer server, EntityPlayer entity) {
-         super(server, entity);
-@@ -194,6 +195,58 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -194,6 +194,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
                  footer == null ? null : new BaseComponent[]{footer});
      }
  
@@ -669,9 +661,6 @@ index 49477a0f4d237db75d869ed91dc5088f4b4385fe..6d2357123c716f5f43d7f0f08fc96add
 +
 +    @Override
 +    public void sendPlayerListHeaderAndFooter(final net.kyori.adventure.text.Component header, final net.kyori.adventure.text.Component footer) {
-+        playerListHeader = header;
-+        playerListFooter = footer;
-+
 +        PacketPlayOutPlayerListHeaderFooter packet = new PacketPlayOutPlayerListHeaderFooter();
 +        packet.adventure$header = header;
 +        packet.adventure$footer = footer;
@@ -681,8 +670,6 @@ index 49477a0f4d237db75d869ed91dc5088f4b4385fe..6d2357123c716f5f43d7f0f08fc96add
 +
 +    @Override
 +    public void sendPlayerListHeader(final net.kyori.adventure.text.Component header) {
-+        playerListHeader = header;
-+
 +        PacketPlayOutPlayerListHeaderFooter packet = new PacketPlayOutPlayerListHeaderFooter();
 +        packet.adventure$header = header;
 +
@@ -691,28 +678,16 @@ index 49477a0f4d237db75d869ed91dc5088f4b4385fe..6d2357123c716f5f43d7f0f08fc96add
 +
 +    @Override
 +    public void sendPlayerListFooter(final net.kyori.adventure.text.Component footer) {
-+        playerListFooter = footer;
-+
 +        PacketPlayOutPlayerListHeaderFooter packet = new PacketPlayOutPlayerListHeaderFooter();
 +        packet.adventure$footer = footer;
 +
 +        getHandle().playerConnection.sendPacket(packet);
 +    }
-+
-+    @Override
-+    public net.kyori.adventure.text.Component playerListHeader() {
-+        return playerListHeader;
-+    }
-+
-+    @Override
-+    public net.kyori.adventure.text.Component playerListFooter() {
-+        return playerListFooter;
-+    }
 +    // PandaSpigot end
  
      @Override
      public void setTitleTimes(int fadeInTicks, int stayTicks, int fadeOutTicks) {
-@@ -258,14 +311,34 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -258,14 +293,34 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  
@@ -749,7 +724,7 @@ index 49477a0f4d237db75d869ed91dc5088f4b4385fe..6d2357123c716f5f43d7f0f08fc96add
      }
  
      @Override
-@@ -286,6 +359,33 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -286,6 +341,33 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  
@@ -783,7 +758,7 @@ index 49477a0f4d237db75d869ed91dc5088f4b4385fe..6d2357123c716f5f43d7f0f08fc96add
      @Override
      public boolean equals(Object obj) {
          if (!(obj instanceof OfflinePlayer)) {
-@@ -314,6 +414,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -314,6 +396,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          getHandle().playerConnection.disconnect(message == null ? "" : message);
      }
  

--- a/patches/server/0114-Adventure-API.patch
+++ b/patches/server/0114-Adventure-API.patch
@@ -398,7 +398,7 @@ index 20016b5c4f6c3aa8782555b3ffeeead0b7c46844..98080450b4fa91129d96022b1175b93f
              } else {
                  packetdataserializer.a(this.b);
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 303d145fedb3488df4686f83a63c04c0c24eacc9..e505ea398c523a839dfbd2e1d83b4ebde7a80ac1 100644
+index 303d145fedb3488df4686f83a63c04c0c24eacc9..676e597d2fcaf6956f0ede46b2623e2361117661 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -167,11 +167,17 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
@@ -421,7 +421,7 @@ index 303d145fedb3488df4686f83a63c04c0c24eacc9..e505ea398c523a839dfbd2e1d83b4ebd
  
          if (this.server.getServer().isRunning()) {
              this.server.getPluginManager().callEvent(event);
-@@ -182,21 +188,20 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
+@@ -182,16 +188,15 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
              return;
          }
          // Send the possibly modified leave message
@@ -442,13 +442,6 @@ index 303d145fedb3488df4686f83a63c04c0c24eacc9..e505ea398c523a839dfbd2e1d83b4ebd
          this.networkManager.k();
          // CraftBukkit - Don't wait
          this.minecraftServer.postToMainThread(new Runnable() {
--             public void run() {
--                 PlayerConnection.this.networkManager.l();
-+            public void run() {
-+                PlayerConnection.this.networkManager.l();
-             }
-         });
-     }
 @@ -896,10 +901,12 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
          */
  

--- a/patches/server/0114-Adventure-API.patch
+++ b/patches/server/0114-Adventure-API.patch
@@ -1,0 +1,877 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MasterDash5 <constant4337@molecularmail.com>
+Date: Sun, 7 Sep 2025 13:58:56 -0600
+Subject: [PATCH] Adventure API
+
+
+diff --git a/build.gradle.kts b/build.gradle.kts
+index 83dcd2285e088f8620831e20893c44a122779daf..8c8aa2274fd97c9d3a2f24700f58e045e984f75d 100644
+--- a/build.gradle.kts
++++ b/build.gradle.kts
+@@ -4,6 +4,7 @@ plugins {
+ }
+ 
+ val minecraftVersion = "1_8_R3"
++val adventureVersion = "4.24.0" // PandaSpigot - Adventure
+ 
+ repositories {
+     maven(url = "https://libraries.minecraft.net")
+@@ -43,7 +44,7 @@ dependencies {
+     implementation("org.jline:jline-terminal-jni:3.30.3")
+     // PandaSpigot end
+ 
+-    implementation("net.kyori:adventure-key:4.21.0") // PandaSpigot - Add Channel initialization listeners
++    implementation("net.kyori:adventure-text-serializer-json:$adventureVersion") // PandaSpigot - Adventure
+ 
+     testImplementation("junit:junit:4.11")
+     testImplementation("org.hamcrest:hamcrest-library:1.3")
+diff --git a/src/main/java/com/hpfxd/pandaspigot/adventure/NBTLegacyHoverEventSerializer.java b/src/main/java/com/hpfxd/pandaspigot/adventure/NBTLegacyHoverEventSerializer.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..858987bb7be1fa84e7ac35dde2a8d1a4cf817823
+--- /dev/null
++++ b/src/main/java/com/hpfxd/pandaspigot/adventure/NBTLegacyHoverEventSerializer.java
+@@ -0,0 +1,97 @@
++package com.hpfxd.pandaspigot.adventure;
++
++import com.google.common.base.CaseFormat;
++import net.kyori.adventure.key.Key;
++import net.kyori.adventure.nbt.api.BinaryTagHolder;
++import net.kyori.adventure.text.Component;
++import net.kyori.adventure.text.event.HoverEvent;
++import net.kyori.adventure.text.serializer.json.LegacyHoverEventSerializer;
++import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
++import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
++import net.kyori.adventure.util.Codec;
++import net.minecraft.server.MojangsonParseException;
++import net.minecraft.server.MojangsonParser;
++import net.minecraft.server.NBTBase;
++import net.minecraft.server.NBTTagCompound;
++
++import java.io.IOException;
++import java.util.UUID;
++
++public class NBTLegacyHoverEventSerializer implements LegacyHoverEventSerializer {
++
++    public static final Codec<NBTTagCompound, String, MojangsonParseException, RuntimeException> SNBT_CODEC = Codec.codec(MojangsonParser::parse, NBTBase::toString);
++
++    public static final String ITEM_TYPE = "id";
++    public static final String ITEM_COUNT = "Count";
++    public static final String ITEM_TAG = "tag";
++
++    public static final String ENTITY_NAME = "name";
++    public static final String ENTITY_TYPE = "type";
++    public static final String ENTITY_ID = "id";
++
++    @Override
++    public HoverEvent.ShowItem deserializeShowItem(Component input) throws IOException {
++        String raw = PlainTextComponentSerializer.plainText().serialize(input);
++
++        try {
++            NBTTagCompound contents = SNBT_CODEC.decode(raw);
++            NBTTagCompound tag = contents.getCompound(ITEM_TAG);
++
++            return HoverEvent.ShowItem.showItem(
++                Key.key(contents.getString(ITEM_TYPE)),
++                contents.hasKey(ITEM_COUNT) ? contents.getByte(ITEM_COUNT) : 1,
++                tag.isEmpty() ? null : BinaryTagHolder.encode(tag, SNBT_CODEC)
++            );
++        } catch (MojangsonParseException ex) {
++            throw new IOException(ex);
++        }
++    }
++
++    @Override
++    public HoverEvent.ShowEntity deserializeShowEntity(Component input, Codec.Decoder<Component, String, ? extends RuntimeException> componentDecoder) throws IOException {
++        String raw = PlainTextComponentSerializer.plainText().serialize(input);
++
++        try {
++            NBTTagCompound contents = SNBT_CODEC.decode(raw);
++
++            return HoverEvent.ShowEntity.showEntity(
++                Key.key("minecraft", CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, contents.getString(ENTITY_TYPE))),
++                UUID.fromString(contents.getString(ENTITY_ID)),
++                LegacyComponentSerializer.legacySection().deserialize(contents.getString(ENTITY_NAME))
++            );
++        } catch (MojangsonParseException ex) {
++            throw new IOException(ex);
++        }
++    }
++
++    @Override
++    public Component serializeShowItem(HoverEvent.ShowItem input) throws IOException {
++        NBTTagCompound tag = new NBTTagCompound();
++        tag.setString(ITEM_TYPE, input.item().asString());
++        tag.setByte(ITEM_COUNT, (byte) input.count());
++
++        if (input.nbt() != null) {
++            try {
++                tag.set(ITEM_TAG, input.nbt().get(SNBT_CODEC));
++            } catch (MojangsonParseException ex) {
++                throw new IOException(ex);
++            }
++        }
++
++        return Component.text(SNBT_CODEC.encode(tag));
++    }
++
++    @Override
++    public Component serializeShowEntity(HoverEvent.ShowEntity input, Codec.Encoder<Component, String, ? extends RuntimeException> componentEncoder) {
++        NBTTagCompound tag = new NBTTagCompound();
++        tag.setString(ENTITY_ID, input.id().toString());
++        tag.setString(ENTITY_TYPE, CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, input.type().value()));
++
++        if (input.name() != null) {
++            tag.setString(ENTITY_NAME, LegacyComponentSerializer.legacySection().serialize(input.name()));
++        }
++
++        return Component.text(SNBT_CODEC.encode(tag));
++    }
++
++}
+diff --git a/src/main/java/com/hpfxd/pandaspigot/adventure/PandaAdventure.java b/src/main/java/com/hpfxd/pandaspigot/adventure/PandaAdventure.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..a09959c1cdced67149e0b3575fe6a087f224c149
+--- /dev/null
++++ b/src/main/java/com/hpfxd/pandaspigot/adventure/PandaAdventure.java
+@@ -0,0 +1,74 @@
++package com.hpfxd.pandaspigot.adventure;
++
++import net.kyori.adventure.text.Component;
++import net.kyori.adventure.text.serializer.json.JSONComponentSerializer;
++import net.kyori.adventure.text.serializer.json.JSONOptions;
++import net.md_5.bungee.api.chat.BaseComponent;
++import net.md_5.bungee.chat.ComponentSerializer;
++import net.minecraft.server.IChatBaseComponent;
++
++import java.util.ArrayList;
++import java.util.List;
++
++public final class PandaAdventure {
++
++    public static final JSONComponentSerializer SERIALIZER = JSONComponentSerializer.builder()
++        .options(JSONOptions.byDataVersion().at(0))
++        .legacyHoverEventSerializer(new NBTLegacyHoverEventSerializer())
++        .build();
++
++    private PandaAdventure() {}
++
++    public static Component asAdventure(IChatBaseComponent component) {
++        return SERIALIZER.deserialize(IChatBaseComponent.ChatSerializer.a(component));
++    }
++
++    public static Component asAdventure(BaseComponent[] components) {
++        return SERIALIZER.deserialize(ComponentSerializer.toString(components));
++    }
++
++    public static List<Component> asAdventure(List<IChatBaseComponent> components) {
++        List<Component> list = new ArrayList<>(components.size());
++
++        for (IChatBaseComponent component : components) {
++            list.add(asAdventure(component));
++        }
++
++        return list;
++    }
++
++    public static Component[] asAdventure(IChatBaseComponent[] components) {
++        Component[] array = new Component[components.length];
++
++        for (int i = 0; i < components.length; i++) {
++            array[i] = asAdventure(components[i]);
++        }
++
++        return array;
++    }
++
++    public static IChatBaseComponent asVanilla(Component component) {
++        return IChatBaseComponent.ChatSerializer.a(SERIALIZER.serialize(component));
++    }
++
++    public static List<IChatBaseComponent> asVanilla(List<Component> components) {
++        List<IChatBaseComponent> list = new ArrayList<>(components.size());
++
++        for (Component component : components) {
++            list.add(asVanilla(component));
++        }
++
++        return list;
++    }
++
++    public static IChatBaseComponent[] asVanilla(Component[] components) {
++        IChatBaseComponent[] array = new IChatBaseComponent[components.length];
++
++        for (int i = 0; i < components.length; i++) {
++            array[i] = asVanilla(components[i]);
++        }
++
++        return array;
++    }
++
++}
+diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
+index b4f301a3eb660b9bf080c4f6b4e3bbaa3678a8d6..d981c89fd182bae75c928616edc5944f6ee860f8 100644
+--- a/src/main/java/net/minecraft/server/EntityPlayer.java
++++ b/src/main/java/net/minecraft/server/EntityPlayer.java
+@@ -52,7 +52,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+     public boolean viewingCredits;
+ 
+     // CraftBukkit start
+-    public String displayName;
++    public net.kyori.adventure.text.Component displayName; // PandaSpigot - Adventure
+     public IChatBaseComponent listName;
+     public org.bukkit.Location compassTarget;
+     public int newExp = 0;
+@@ -112,7 +112,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+         }
+ 
+         // CraftBukkit start
+-        this.displayName = this.getName();
++        this.displayName = net.kyori.adventure.text.Component.text(this.getName()); // PandaSpigot - Adventure
+         // this.canPickUpLoot = true; TODO
+         this.maxHealthCache = this.getMaxHealth();
+         // CraftBukkit end
+@@ -429,18 +429,16 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+ 
+         IChatBaseComponent chatmessage = this.bs().b();
+ 
+-        String deathmessage = chatmessage.c();
+-        org.bukkit.event.entity.PlayerDeathEvent event = CraftEventFactory.callPlayerDeathEvent(this, loot, deathmessage, keepInventory);
++        // PandaSpigot start - Adventure
++        //String deathmessage = chatmessage.c();
++        org.bukkit.event.entity.PlayerDeathEvent event = CraftEventFactory.callPlayerDeathEvent(this, loot, com.hpfxd.pandaspigot.adventure.PandaAdventure.asAdventure(chatmessage), keepInventory);
+ 
+-        String deathMessage = event.getDeathMessage();
++        net.kyori.adventure.text.Component deathMessage = event.deathMessage();
+ 
+-        if (deathMessage != null && deathMessage.length() > 0 && this.world.getGameRules().getBoolean("showDeathMessages")) { // TODO: allow plugins to override?
+-            if (deathMessage.equals(deathmessage)) {
+-                this.server.getPlayerList().sendMessage(chatmessage);
+-            } else {
+-                this.server.getPlayerList().sendMessage(org.bukkit.craftbukkit.util.CraftChatMessage.fromString(deathMessage));
+-            }
++        if (deathMessage != null && !deathMessage.equals(net.kyori.adventure.text.Component.empty()) && this.world.getGameRules().getBoolean("showDeathMessages")) { // TODO: allow plugins to override?
++            this.server.getPlayerList().sendMessage(com.hpfxd.pandaspigot.adventure.PandaAdventure.asVanilla(deathMessage));
+         }
++        // PandaSpigot end
+ 
+         // we clean the player's inventory after the EntityDeathEvent is called so plugins can get the exact state of the inventory.
+         if (!event.getKeepInventory()) {
+diff --git a/src/main/java/net/minecraft/server/LoginListener.java b/src/main/java/net/minecraft/server/LoginListener.java
+index 9faa98501275cbd03a34dcc83f281d1e3f40a6e0..5d50379171901bd9cd0fce6b379deeadb00598aa 100644
+--- a/src/main/java/net/minecraft/server/LoginListener.java
++++ b/src/main/java/net/minecraft/server/LoginListener.java
+@@ -75,17 +75,20 @@ public class LoginListener implements PacketLoginInListener, IUpdatePlayerListBo
+     }
+ 
+     public void disconnect(String s) {
+-        try {
+-            LoginListener.c.info("Disconnecting " + this.d() + ": " + s);
+-            ChatComponentText chatcomponenttext = new ChatComponentText(s);
++        disconnect(new ChatComponentText(s)); // PandaSpigot - Adventure
++    }
+ 
+-            this.networkManager.handle(new PacketLoginOutDisconnect(chatcomponenttext));
+-            this.networkManager.close(chatcomponenttext);
++    // PandaSpigot start - Adventure
++    public void disconnect(IChatBaseComponent ichatbasecomponent) {
++        try {
++            LoginListener.c.info("Disconnecting {}: {}", this.d(), ichatbasecomponent.getText());
++            this.networkManager.handle(new PacketLoginOutDisconnect(ichatbasecomponent));
++            this.networkManager.close(ichatbasecomponent);
+         } catch (Exception exception) {
+             LoginListener.c.error("Error whilst disconnecting player", exception);
+         }
+-
+     }
++    // PandaSpigot end
+ 
+     // Spigot start
+     public void initUUID()
+@@ -278,12 +281,12 @@ public class LoginListener implements PacketLoginInListener, IUpdatePlayerListBo
+ 
+                                 LoginListener.this.server.processQueue.add(waitable);
+                                 if (waitable.get() != PlayerPreLoginEvent.Result.ALLOWED) {
+-                                    disconnect(event.getKickMessage());
++                                    disconnect(com.hpfxd.pandaspigot.adventure.PandaAdventure.asVanilla(event.kickMessage())); // PandaSpigot - Adventure
+                                     return;
+                                 }
+                             } else {
+                                 if (asyncEvent.getLoginResult() != AsyncPlayerPreLoginEvent.Result.ALLOWED) {
+-                                    disconnect(asyncEvent.getKickMessage());
++                                    disconnect(com.hpfxd.pandaspigot.adventure.PandaAdventure.asVanilla(asyncEvent.kickMessage())); // PandaSpigot - Adventure
+                                     return;
+                                 }
+                             }
+diff --git a/src/main/java/net/minecraft/server/PacketPlayOutChat.java b/src/main/java/net/minecraft/server/PacketPlayOutChat.java
+index 6cd5df2e8dfae1829d17c117b4a7422711a0db22..48fcdafeb56f5cae5361d3981170d58c0b5b717b 100644
+--- a/src/main/java/net/minecraft/server/PacketPlayOutChat.java
++++ b/src/main/java/net/minecraft/server/PacketPlayOutChat.java
+@@ -7,6 +7,7 @@ public class PacketPlayOutChat implements Packet<PacketListenerPlayOut> {
+     private IChatBaseComponent a;
+     public net.md_5.bungee.api.chat.BaseComponent[] components; // Spigot
+     private byte b;
++    public net.kyori.adventure.text.Component adventure$message; // PandaSpigot - Adventure;
+ 
+     public PacketPlayOutChat() {}
+ 
+@@ -26,7 +27,11 @@ public class PacketPlayOutChat implements Packet<PacketListenerPlayOut> {
+ 
+     public void b(PacketDataSerializer packetdataserializer) throws IOException {
+         // Spigot start
+-        if (components != null) {
++        // PandaSpigot start - Adventure
++        if (adventure$message != null) {
++            packetdataserializer.a(com.hpfxd.pandaspigot.adventure.PandaAdventure.asVanilla(adventure$message));
++        } else if (components != null) {
++        // PandaSpigot end
+             packetdataserializer.a(net.md_5.bungee.chat.ComponentSerializer.toString(components));
+         } else {
+             packetdataserializer.a(this.a);
+diff --git a/src/main/java/net/minecraft/server/PacketPlayOutPlayerListHeaderFooter.java b/src/main/java/net/minecraft/server/PacketPlayOutPlayerListHeaderFooter.java
+index 795e70aa7134065dad1841709afc1a2ad5bbf013..4d0bb38bae58eb994f1a46d4d4df16828298052b 100644
+--- a/src/main/java/net/minecraft/server/PacketPlayOutPlayerListHeaderFooter.java
++++ b/src/main/java/net/minecraft/server/PacketPlayOutPlayerListHeaderFooter.java
+@@ -8,6 +8,7 @@ public class PacketPlayOutPlayerListHeaderFooter implements Packet<PacketListene
+ 
+     private IChatBaseComponent a;
+     private IChatBaseComponent b;
++    public net.kyori.adventure.text.Component adventure$header, adventure$footer; // PandaSpigot - Adventure
+ 
+     public PacketPlayOutPlayerListHeaderFooter() {}
+ 
+@@ -22,13 +23,21 @@ public class PacketPlayOutPlayerListHeaderFooter implements Packet<PacketListene
+ 
+     public void b(PacketDataSerializer packetdataserializer) throws IOException {
+         // Paper start
+-        if (this.header != null) {
++        // PandaSpigot start - Adventure
++        if (this.adventure$header != null) {
++            packetdataserializer.a(com.hpfxd.pandaspigot.adventure.PandaAdventure.asVanilla(adventure$header));
++        } else if (this.header != null) {
++        // PandaSpigot end
+             packetdataserializer.a(net.md_5.bungee.chat.ComponentSerializer.toString(this.header));
+         } else {
+             packetdataserializer.a(this.a);
+         }
+ 
+-        if (this.footer != null) {
++        // PandaSpigot start - Adventure
++        if (this.adventure$footer != null) {
++            packetdataserializer.a(com.hpfxd.pandaspigot.adventure.PandaAdventure.asVanilla(adventure$footer));
++        } else if (this.footer != null) {
++        // PandaSpigot end
+             packetdataserializer.a(net.md_5.bungee.chat.ComponentSerializer.toString(this.footer));
+         } else {
+             packetdataserializer.a(this.b);
+diff --git a/src/main/java/net/minecraft/server/PacketPlayOutTitle.java b/src/main/java/net/minecraft/server/PacketPlayOutTitle.java
+index 20016b5c4f6c3aa8782555b3ffeeead0b7c46844..98080450b4fa91129d96022b1175b93fb54f1d23 100644
+--- a/src/main/java/net/minecraft/server/PacketPlayOutTitle.java
++++ b/src/main/java/net/minecraft/server/PacketPlayOutTitle.java
+@@ -12,6 +12,7 @@ public class PacketPlayOutTitle implements Packet<PacketListenerPlayOut> {
+ 
+     // Paper start
+     public net.md_5.bungee.api.chat.BaseComponent[] components;
++    public net.kyori.adventure.text.Component adventure$text; // PandaSpigot - Adventure
+ 
+     public PacketPlayOutTitle(EnumTitleAction action, net.md_5.bungee.api.chat.BaseComponent[] components, int fadeIn, int stay, int fadeOut) {
+         this.a = action;
+@@ -58,7 +59,11 @@ public class PacketPlayOutTitle implements Packet<PacketListenerPlayOut> {
+         packetdataserializer.a((Enum) this.a);
+         if (this.a == EnumTitleAction.TITLE || this.a == EnumTitleAction.SUBTITLE) {
+             // Paper start
+-            if (this.components != null) {
++            // PandaSpigot start - Adventure
++            if (this.adventure$text != null) {
++                packetdataserializer.a(com.hpfxd.pandaspigot.adventure.PandaAdventure.asVanilla(adventure$text));
++            } else if (this.components != null) {
++            // PandaSpigot end
+                 packetdataserializer.a(net.md_5.bungee.chat.ComponentSerializer.toString(components));
+             } else {
+                 packetdataserializer.a(this.b);
+diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
+index 303d145fedb3488df4686f83a63c04c0c24eacc9..e505ea398c523a839dfbd2e1d83b4ebde7a80ac1 100644
+--- a/src/main/java/net/minecraft/server/PlayerConnection.java
++++ b/src/main/java/net/minecraft/server/PlayerConnection.java
+@@ -167,11 +167,17 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
+         return this.networkManager;
+     }
+ 
++    // PandaSpigot start - Adventure
+     public void disconnect(String s) {
++        disconnect(new ChatComponentText(s));
++    }
++    // PandaSpigot end
++
++    public void disconnect(IChatBaseComponent ichatbasecomponent) { // PandaSpigot - Adventure
+         // CraftBukkit start - fire PlayerKickEvent
+-        String leaveMessage = EnumChatFormat.YELLOW + this.player.getName() + " left the game.";
++        net.kyori.adventure.text.Component leaveMessage = net.kyori.adventure.text.Component.translatable("multiplayer.player.left").arguments(net.kyori.adventure.text.Component.text(this.getPlayer().getName())).color(net.kyori.adventure.text.format.NamedTextColor.YELLOW); // PandaSpigot - Adventure
+ 
+-        PlayerKickEvent event = new PlayerKickEvent(this.server.getPlayer(this.player), s, leaveMessage);
++        PlayerKickEvent event = new PlayerKickEvent(this.server.getPlayer(this.player), com.hpfxd.pandaspigot.adventure.PandaAdventure.asAdventure(ichatbasecomponent), leaveMessage); // PandaSpigot - Adventure
+ 
+         if (this.server.getServer().isRunning()) {
+             this.server.getPluginManager().callEvent(event);
+@@ -182,21 +188,20 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
+             return;
+         }
+         // Send the possibly modified leave message
+-        s = event.getReason();
++        IChatBaseComponent kickReason = com.hpfxd.pandaspigot.adventure.PandaAdventure.asVanilla(event.reason()); // PandaSpigot - Adventure
+         // CraftBukkit end
+-        final ChatComponentText chatcomponenttext = new ChatComponentText(s);
+ 
+-        this.networkManager.a(new PacketPlayOutKickDisconnect(chatcomponenttext), new GenericFutureListener() {
++        this.networkManager.a(new PacketPlayOutKickDisconnect(kickReason), new GenericFutureListener() { // PandaSpigot - Adventure
+             public void operationComplete(Future future) throws Exception { // CraftBukkit - fix decompile error
+-                PlayerConnection.this.networkManager.close(chatcomponenttext);
++                PlayerConnection.this.networkManager.close(kickReason); // PandaSpigot - Adventure
+             }
+         }, new GenericFutureListener[0]);
+-        this.a(chatcomponenttext); // CraftBukkit - fire quit instantly
++        this.a(kickReason); // CraftBukkit - fire quit instantly // PandaSpigot - Adventure
+         this.networkManager.k();
+         // CraftBukkit - Don't wait
+         this.minecraftServer.postToMainThread(new Runnable() {
+-             public void run() {
+-                 PlayerConnection.this.networkManager.l();
++            public void run() {
++                PlayerConnection.this.networkManager.l();
+             }
+         });
+     }
+@@ -896,10 +901,12 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
+         */
+ 
+         this.player.q();
+-        String quitMessage = this.minecraftServer.getPlayerList().disconnect(this.player);
+-        if ((quitMessage != null) && (quitMessage.length() > 0)) {
+-            this.minecraftServer.getPlayerList().sendMessage(CraftChatMessage.fromString(quitMessage));
++        // PandaSpigot start - Adventure
++        net.kyori.adventure.text.Component quitMessage = this.minecraftServer.getPlayerList().disconnect(this.player);
++        if (quitMessage != null && !quitMessage.equals(net.kyori.adventure.text.Component.empty())) {
++            this.minecraftServer.getPlayerList().sendMessage(com.hpfxd.pandaspigot.adventure.PandaAdventure.asVanilla(quitMessage));
+         }
++        // PandaSpigot end
+         // CraftBukkit end
+         if (this.minecraftServer.T() && this.player.getName().equals(this.minecraftServer.S())) {
+             PlayerConnection.c.info("Stopping singleplayer server as player logged out");
+@@ -1937,7 +1944,7 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
+             this.server.getPluginManager().callEvent(event);
+ 
+             if (!event.isCancelled()) {
+-                System.arraycopy(org.bukkit.craftbukkit.block.CraftSign.sanitizeLines(event.getLines()), 0, tileentitysign.lines, 0, 4);
++                System.arraycopy(com.hpfxd.pandaspigot.adventure.PandaAdventure.asVanilla(event.lines()).toArray(new IChatBaseComponent[0]), 0, tileentitysign.lines, 0, 4); // PandaSpigot - Adventure
+                 tileentitysign.isEditable = false;
+              }
+             // CraftBukkit end
+diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
+index 5cab6e68c85d794eb6e492c73f7d7694e20693a5..c4c5b16c42719c802c928c871858f2c99021c9db 100644
+--- a/src/main/java/net/minecraft/server/PlayerList.java
++++ b/src/main/java/net/minecraft/server/PlayerList.java
+@@ -158,15 +158,18 @@ public abstract class PlayerList {
+         // CraftBukkit start - login message is handled in the event
+         // ChatMessage chatmessage;
+ 
+-        String joinMessage;
++        // PandaSpigot start - Adventure
++        net.kyori.adventure.text.Component joinMessage;
+         if (!entityplayer.getName().equalsIgnoreCase(s)) {
+             // chatmessage = new ChatMessage("multiplayer.player.joined.renamed", new Object[] { entityplayer.getScoreboardDisplayName(), s});
+-            joinMessage = "\u00A7e" + LocaleI18n.a("multiplayer.player.joined.renamed", entityplayer.getName(), s);
++            joinMessage = net.kyori.adventure.text.Component.translatable("multiplayer.player.joined.renamed").arguments(net.kyori.adventure.text.Component.text(entityplayer.getName()), net.kyori.adventure.text.Component.text(s));
+         } else {
+             // chatmessage = new ChatMessage("multiplayer.player.joined", new Object[] { entityplayer.getScoreboardDisplayName()});
+-            joinMessage = "\u00A7e" + LocaleI18n.a("multiplayer.player.joined", entityplayer.getName());
++            joinMessage = net.kyori.adventure.text.Component.translatable("multiplayer.player.joined").arguments(net.kyori.adventure.text.Component.text(entityplayer.getName()));
+         }
+ 
++        joinMessage = joinMessage.color(net.kyori.adventure.text.format.NamedTextColor.YELLOW);
++        // PandaSpigot end
+         // chatmessage.getChatModifier().setColor(EnumChatFormat.YELLOW);
+         // this.sendMessage(chatmessage);
+         this.onPlayerJoin(entityplayer, joinMessage);
+@@ -301,7 +304,7 @@ public abstract class PlayerList {
+ 
+     }
+ 
+-    public void onPlayerJoin(EntityPlayer entityplayer, String joinMessage) { // CraftBukkit added param
++    public void onPlayerJoin(EntityPlayer entityplayer, net.kyori.adventure.text.Component joinMessage) { // CraftBukkit added param // PandaSpigot - Adventure
+         this.players.add(entityplayer);
+         this.playersByName.put(entityplayer.getName(), entityplayer); // Spigot
+         this.j.put(entityplayer.getUniqueID(), entityplayer);
+@@ -312,13 +315,13 @@ public abstract class PlayerList {
+         PlayerJoinEvent playerJoinEvent = new PlayerJoinEvent(cserver.getPlayer(entityplayer), joinMessage);
+         cserver.getPluginManager().callEvent(playerJoinEvent);
+ 
+-        joinMessage = playerJoinEvent.getJoinMessage();
++        // PandaSpigot start - Adventure
++        joinMessage = playerJoinEvent.joinMessage();
+ 
+-        if (joinMessage != null && joinMessage.length() > 0) {
+-            for (IChatBaseComponent line : org.bukkit.craftbukkit.util.CraftChatMessage.fromString(joinMessage)) {
+-                server.getPlayerList().sendAll(new PacketPlayOutChat(line));
+-            }
++        if (joinMessage != null && !joinMessage.equals(net.kyori.adventure.text.Component.empty())) {
++            server.getPlayerList().sendMessage(com.hpfxd.pandaspigot.adventure.PandaAdventure.asVanilla(joinMessage));
+         }
++        // PandaSpigot end
+ 
+         ChunkIOExecutor.adjustPoolSize(getPlayerCount());
+         // CraftBukkit end
+@@ -359,13 +362,13 @@ public abstract class PlayerList {
+         entityplayer.u().getPlayerChunkMap().movePlayer(entityplayer);
+     }
+ 
+-    public String disconnect(EntityPlayer entityplayer) { // CraftBukkit - return string
++    public net.kyori.adventure.text.Component disconnect(EntityPlayer entityplayer) { // CraftBukkit - return string // PandaSpigot - Adventure
+         entityplayer.b(StatisticList.f);
+ 
+         // CraftBukkit start - Quitting must be before we do final save of data, in case plugins need to modify it
+         org.bukkit.craftbukkit.event.CraftEventFactory.handleInventoryCloseEvent(entityplayer);
+ 
+-        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(cserver.getPlayer(entityplayer), "\u00A7e" + entityplayer.getName() + " left the game.");
++        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(cserver.getPlayer(entityplayer), net.kyori.adventure.text.Component.translatable("multiplayer.player.left").arguments(net.kyori.adventure.text.Component.text(entityplayer.getName())).color(net.kyori.adventure.text.format.NamedTextColor.YELLOW)); // PandaSpigot - Adventure
+         cserver.getPluginManager().callEvent(playerQuitEvent);
+         entityplayer.getBukkitEntity().disconnect(playerQuitEvent.getQuitMessage());
+         // CraftBukkit end
+@@ -408,7 +411,7 @@ public abstract class PlayerList {
+ 
+         ChunkIOExecutor.adjustPoolSize(this.getPlayerCount()); // CraftBukkit
+ 
+-        return playerQuitEvent.getQuitMessage(); // CraftBukkit
++        return playerQuitEvent.quitMessage(); // CraftBukkit // PandaSpigot - Adventure
+     }
+ 
+     // CraftBukkit start - Whole method, SocketAddress to LoginListener, added hostname to signature, return EntityPlayer
+@@ -476,7 +479,7 @@ public abstract class PlayerList {
+ 
+         cserver.getPluginManager().callEvent(event);
+         if (event.getResult() != PlayerLoginEvent.Result.ALLOWED) {
+-            loginlistener.disconnect(event.getKickMessage());
++            loginlistener.disconnect(com.hpfxd.pandaspigot.adventure.PandaAdventure.asVanilla(event.kickMessage())); // PandaSpigot - Adventure
+             return null;
+         }
+         return entity;
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 8b8b19c8afa32af136733bd7f77ed9417fab17fd..2eac381a825ed0edabd12816432f6d2d655887ef 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -1832,6 +1832,13 @@ public final class CraftServer implements Server {
+     }
+     // PandaSpigot end
+ 
++    // PandaSpigot start - Adventure
++    @Override
++    public Iterable<? extends net.kyori.adventure.audience.Audience> audiences() {
++        return com.google.common.collect.Iterables.concat(Collections.singleton(getConsoleSender()), getOnlinePlayers());
++    }
++    // PandaSpigot end
++
+     private final Spigot spigot = new Spigot()
+     {
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java b/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
+index 43adfccd72c0629f5b93c735119fa4f84074d12b..f82bc7aa44e7299768aabf00fef7a995027ae1fe 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
+@@ -11,7 +11,7 @@ import org.bukkit.craftbukkit.util.CraftChatMessage;
+ 
+ public class CraftSign extends CraftBlockState implements Sign {
+     private final TileEntitySign sign;
+-    private final String[] lines;
++    private final net.kyori.adventure.text.Component[] lines = new net.kyori.adventure.text.Component[4]; // PandaSpigot - Adventure
+ 
+     public CraftSign(final Block block) {
+         super(block);
+@@ -20,40 +20,54 @@ public class CraftSign extends CraftBlockState implements Sign {
+         sign = (TileEntitySign) world.getTileEntityAt(getX(), getY(), getZ());
+         // Spigot start
+         if (sign == null) {
+-            lines = new String[]{"", "", "", ""};
++            java.util.Arrays.fill(lines, net.kyori.adventure.text.Component.empty()); // PandaSpigot - Adventure
+             return;
+         }
+         // Spigot end
+-        lines = new String[sign.lines.length];
+-        System.arraycopy(revertComponents(sign.lines), 0, lines, 0, lines.length);
++        System.arraycopy(com.hpfxd.pandaspigot.adventure.PandaAdventure.asAdventure(sign.lines), 0, lines, 0, lines.length); // PandaSpigot - Adventure
+     }
+ 
+     public CraftSign(final Material material, final TileEntitySign te) {
+         super(material);
+         sign = te;
+-        lines = new String[sign.lines.length];
+-        System.arraycopy(revertComponents(sign.lines), 0, lines, 0, lines.length);
++        System.arraycopy(com.hpfxd.pandaspigot.adventure.PandaAdventure.asAdventure(sign.lines), 0, lines, 0, lines.length); // PandaSpigot - Adventure
+     }
+ 
+     public String[] getLines() {
+-        return lines;
++        return java.util.Arrays.stream(lines).map(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection()::serialize).toArray(String[]::new); // PandaSpigot - Adventure
+     }
+ 
+     public String getLine(int index) throws IndexOutOfBoundsException {
+-        return lines[index];
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(lines[index]); // PandaSpigot - Adventure
+     }
+ 
+     public void setLine(int index, String line) throws IndexOutOfBoundsException {
++        lines[index] = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(line); // PandaSpigot - Adventure
++    }
++
++    // PandaSpigot start - Adventure
++    @Override
++    public java.util.List<net.kyori.adventure.text.Component> lines() {
++        return java.util.Arrays.asList(lines);
++    }
++
++    @Override
++    public net.kyori.adventure.text.Component line(int index) throws IndexOutOfBoundsException {
++        return lines[index];
++    }
++
++    @Override
++    public void line(int index, net.kyori.adventure.text.Component line) throws IndexOutOfBoundsException {
+         lines[index] = line;
+     }
++    // PandaSpigot end
+ 
+     @Override
+     public boolean update(boolean force, boolean applyPhysics) {
+         boolean result = super.update(force, applyPhysics);
+ 
+         if (result) {
+-            IChatBaseComponent[] newLines = sanitizeLines(lines);
+-            System.arraycopy(newLines, 0, sign.lines, 0, 4);
++            System.arraycopy(com.hpfxd.pandaspigot.adventure.PandaAdventure.asVanilla(lines), 0, sign.lines, 0, 4); // PandaSpigot - Adventure
+             sign.update();
+         }
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 49477a0f4d237db75d869ed91dc5088f4b4385fe..6d2357123c716f5f43d7f0f08fc96addde2f5342 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -80,6 +80,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     private double health = 20;
+     private boolean scaledHealth = false;
+     private double healthScale = 20;
++    private net.kyori.adventure.text.Component playerListHeader, playerListFooter; // PandaSpigot - Adventure
+ 
+     public CraftPlayer(CraftServer server, EntityPlayer entity) {
+         super(server, entity);
+@@ -194,6 +195,58 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+                 footer == null ? null : new BaseComponent[]{footer});
+     }
+ 
++    // PandaSpigot start - Adventure
++    @Override
++    public void sendMessage(final net.kyori.adventure.identity.Identity identity, final net.kyori.adventure.text.Component component, final net.kyori.adventure.audience.MessageType type) {
++        if (getHandle().playerConnection == null) return;
++
++        PacketPlayOutChat packet = new PacketPlayOutChat(null, (byte) (type == net.kyori.adventure.audience.MessageType.CHAT ? 0 : 1));
++        packet.adventure$message = component;
++        getHandle().playerConnection.sendPacket(packet);
++    }
++
++    @Override
++    public void sendPlayerListHeaderAndFooter(final net.kyori.adventure.text.Component header, final net.kyori.adventure.text.Component footer) {
++        playerListHeader = header;
++        playerListFooter = footer;
++
++        PacketPlayOutPlayerListHeaderFooter packet = new PacketPlayOutPlayerListHeaderFooter();
++        packet.adventure$header = header;
++        packet.adventure$footer = footer;
++
++        getHandle().playerConnection.sendPacket(packet);
++    }
++
++    @Override
++    public void sendPlayerListHeader(final net.kyori.adventure.text.Component header) {
++        playerListHeader = header;
++
++        PacketPlayOutPlayerListHeaderFooter packet = new PacketPlayOutPlayerListHeaderFooter();
++        packet.adventure$header = header;
++
++        getHandle().playerConnection.sendPacket(packet);
++    }
++
++    @Override
++    public void sendPlayerListFooter(final net.kyori.adventure.text.Component footer) {
++        playerListFooter = footer;
++
++        PacketPlayOutPlayerListHeaderFooter packet = new PacketPlayOutPlayerListHeaderFooter();
++        packet.adventure$footer = footer;
++
++        getHandle().playerConnection.sendPacket(packet);
++    }
++
++    @Override
++    public net.kyori.adventure.text.Component playerListHeader() {
++        return playerListHeader;
++    }
++
++    @Override
++    public net.kyori.adventure.text.Component playerListFooter() {
++        return playerListFooter;
++    }
++    // PandaSpigot end
+ 
+     @Override
+     public void setTitleTimes(int fadeInTicks, int stayTicks, int fadeOutTicks) {
+@@ -258,14 +311,34 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     }
+     // Paper end
+ 
++    // PandaSpigot start - Adventure
++    @Override
++    public <T> void sendTitlePart(net.kyori.adventure.title.TitlePart<T> part, T value) {
++        if (part.equals(net.kyori.adventure.title.TitlePart.TITLE) || part.equals(net.kyori.adventure.title.TitlePart.SUBTITLE)) {
++            EnumTitleAction action = part == net.kyori.adventure.title.TitlePart.TITLE ? EnumTitleAction.TITLE : EnumTitleAction.SUBTITLE;
++            IChatBaseComponent ichatbasecomponent = com.hpfxd.pandaspigot.adventure.PandaAdventure.asVanilla((net.kyori.adventure.text.Component) value);
++
++            getHandle().playerConnection.sendPacket(new PacketPlayOutTitle(action, ichatbasecomponent));
++        } else if (part.equals(net.kyori.adventure.title.TitlePart.TIMES)) {
++            net.kyori.adventure.title.Title.Times times = (net.kyori.adventure.title.Title.Times) value;
++            getHandle().playerConnection.sendPacket(new PacketPlayOutTitle(times.fadeIn().getNano(), times.stay().getNano(), times.fadeOut().getNano()));
++        }
++    }
++
++    @Override
++    public void clearTitle() {
++        getHandle().playerConnection.sendPacket(new PacketPlayOutTitle(EnumTitleAction.CLEAR, null));
++    }
++    // PandaSpigot end
++
+     @Override
+     public String getDisplayName() {
+-        return getHandle().displayName;
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(getHandle().displayName); // PandaSpigot - Adventure
+     }
+ 
+     @Override
+     public void setDisplayName(final String name) {
+-        getHandle().displayName = name == null ? getName() : name;
++        getHandle().displayName = name == null ? net.kyori.adventure.text.Component.text(getName()) : net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(name); // PandaSpigot - Adventure
+     }
+ 
+     @Override
+@@ -286,6 +359,33 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         }
+     }
+ 
++    // PandaSpigot start - Adventure
++    @Override
++    public net.kyori.adventure.text.Component displayName() {
++        return getHandle().displayName;
++    }
++
++    @Override
++    public void displayName(net.kyori.adventure.text.Component displayName) {
++        getHandle().displayName = displayName == null ? net.kyori.adventure.text.Component.text(getName()) : displayName;
++    }
++
++    @Override
++    public net.kyori.adventure.text.Component playerListName() {
++        return getHandle().listName == null ? net.kyori.adventure.text.Component.text(getName()) : com.hpfxd.pandaspigot.adventure.PandaAdventure.asAdventure(getHandle().listName);
++    }
++
++    @Override
++    public void playerListName(net.kyori.adventure.text.Component playerListName) {
++        getHandle().listName = playerListName == null ? null : com.hpfxd.pandaspigot.adventure.PandaAdventure.asVanilla(playerListName);
++        for (EntityPlayer player : server.getHandle().players) {
++            if (player.getBukkitEntity().canSee(this)) {
++                player.playerConnection.sendPacket(new PacketPlayOutPlayerInfo(PacketPlayOutPlayerInfo.EnumPlayerInfoAction.UPDATE_DISPLAY_NAME, getHandle()));
++            }
++        }
++    }
++    // PandaSpigot end
++
+     @Override
+     public boolean equals(Object obj) {
+         if (!(obj instanceof OfflinePlayer)) {
+@@ -314,6 +414,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         getHandle().playerConnection.disconnect(message == null ? "" : message);
+     }
+ 
++    // PandaSpigot start - Adventure
++    @Override
++    public void kick(net.kyori.adventure.text.Component message) {
++        org.spigotmc.AsyncCatcher.catchOp( "player kick");
++        if (getHandle().playerConnection == null) return;
++
++        getHandle().playerConnection.disconnect(com.hpfxd.pandaspigot.adventure.PandaAdventure.asVanilla(message));
++    }
++    // PandaSpigot end
++
+     @Override
+     public void setCompassTarget(Location loc) {
+         if (getHandle().playerConnection == null) return;
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index 82ad58bc282f523548d3318c4e52fc1e3cbf7bcc..2b05648ba22a47f7579f64deabbf38132350c0fe 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -392,7 +392,7 @@ public class CraftEventFactory {
+         return event;
+     }
+ 
+-    public static PlayerDeathEvent callPlayerDeathEvent(EntityPlayer victim, List<org.bukkit.inventory.ItemStack> drops, String deathMessage, boolean keepInventory) {
++    public static PlayerDeathEvent callPlayerDeathEvent(EntityPlayer victim, List<org.bukkit.inventory.ItemStack> drops, net.kyori.adventure.text.Component deathMessage, boolean keepInventory) { // PandaSpigot - Adventure
+         CraftPlayer entity = victim.getBukkitEntity();
+         PlayerDeathEvent event = new PlayerDeathEvent(entity, drops, victim.getExpReward(), 0, deathMessage);
+         event.setKeepInventory(keepInventory);
+@@ -421,7 +421,7 @@ public class CraftEventFactory {
+     /**
+      * Server methods
+      */
+-    public static ServerListPingEvent callServerListPingEvent(Server craftServer, InetAddress address, String motd, int numPlayers, int maxPlayers) {
++    public static ServerListPingEvent callServerListPingEvent(Server craftServer, InetAddress address, net.kyori.adventure.text.Component motd, int numPlayers, int maxPlayers) { // PandaSpigot - Adventure
+         ServerListPingEvent event = new ServerListPingEvent(address, motd, numPlayers, maxPlayers);
+         craftServer.getPluginManager().callEvent(event);
+         return event;
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
+index 44b3c3ac151fecebd41b43b7bb6708cb8508dc50..7cc2423fe49c240d3c013023a70ba5c72a11e943 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
+@@ -271,6 +271,19 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+         }
+     }
+ 
++    // PandaSpigot start - Adventure
++    @Override
++    public List<net.kyori.adventure.text.Component> pages() {
++        return com.hpfxd.pandaspigot.adventure.PandaAdventure.asAdventure(pages);
++    }
++
++    @Override
++    public net.kyori.adventure.inventory.Book pages(List<net.kyori.adventure.text.Component> pages) {
++        this.pages = com.hpfxd.pandaspigot.adventure.PandaAdventure.asVanilla(pages);
++        return this;
++    }
++    // PandaSpigot end
++
+     private boolean isValidPage(int page) {
+         return page > 0 && page <= pages.size();
+     }
+@@ -319,7 +332,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+     }
+ 
+     @Override
+-    Builder<String, Object> serialize(Builder<String, Object> builder) {
++    com.google.common.collect.ImmutableMap.Builder<String, Object> serialize(com.google.common.collect.ImmutableMap.Builder<String, Object> builder) { // PandaSpigot - Adventure
+         super.serialize(builder);
+ 
+         if (hasTitle()) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java
+index ae3341c4e7f6239a32ed6c2edc254abcabc6e2a2..c19545bacfd9c8530ca1e383cfacd891a1e20c01 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java
+@@ -129,7 +129,7 @@ class CraftMetaBookSigned extends CraftMetaBook implements BookMeta {
+     }
+ 
+     @Override
+-    Builder<String, Object> serialize(Builder<String, Object> builder) {
++    com.google.common.collect.ImmutableMap.Builder<String, Object> serialize(com.google.common.collect.ImmutableMap.Builder<String, Object> builder) { // PandaSpigot - Adventure
+         super.serialize(builder);
+         return builder;
+     }

--- a/patches/server/0114-Adventure-API.patch
+++ b/patches/server/0114-Adventure-API.patch
@@ -392,20 +392,18 @@ index 20016b5c4f6c3aa8782555b3ffeeead0b7c46844..98080450b4fa91129d96022b1175b93f
              } else {
                  packetdataserializer.a(this.b);
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 303d145fedb3488df4686f83a63c04c0c24eacc9..676e597d2fcaf6956f0ede46b2623e2361117661 100644
+index 303d145fedb3488df4686f83a63c04c0c24eacc9..7e2229575f8688ba0298552ea904b67997a50f13 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -167,11 +167,17 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
-         return this.networkManager;
+@@ -168,10 +168,15 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
      }
  
-+    // PandaSpigot start - Adventure
      public void disconnect(String s) {
++    // PandaSpigot start - Adventure
 +        disconnect(new ChatComponentText(s));
 +    }
++    public void disconnect(IChatBaseComponent ichatbasecomponent) {
 +    // PandaSpigot end
-+
-+    public void disconnect(IChatBaseComponent ichatbasecomponent) { // PandaSpigot - Adventure
          // CraftBukkit start - fire PlayerKickEvent
 -        String leaveMessage = EnumChatFormat.YELLOW + this.player.getName() + " left the game.";
 +        net.kyori.adventure.text.Component leaveMessage = net.kyori.adventure.text.Component.translatable("multiplayer.player.left").arguments(net.kyori.adventure.text.Component.text(this.getPlayer().getName())).color(net.kyori.adventure.text.format.NamedTextColor.YELLOW); // PandaSpigot - Adventure
@@ -415,7 +413,7 @@ index 303d145fedb3488df4686f83a63c04c0c24eacc9..676e597d2fcaf6956f0ede46b2623e23
  
          if (this.server.getServer().isRunning()) {
              this.server.getPluginManager().callEvent(event);
-@@ -182,16 +188,15 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
+@@ -182,16 +187,15 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
              return;
          }
          // Send the possibly modified leave message
@@ -436,7 +434,7 @@ index 303d145fedb3488df4686f83a63c04c0c24eacc9..676e597d2fcaf6956f0ede46b2623e23
          this.networkManager.k();
          // CraftBukkit - Don't wait
          this.minecraftServer.postToMainThread(new Runnable() {
-@@ -896,10 +901,12 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
+@@ -896,10 +900,12 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
          */
  
          this.player.q();
@@ -452,7 +450,7 @@ index 303d145fedb3488df4686f83a63c04c0c24eacc9..676e597d2fcaf6956f0ede46b2623e23
          // CraftBukkit end
          if (this.minecraftServer.T() && this.player.getName().equals(this.minecraftServer.S())) {
              PlayerConnection.c.info("Stopping singleplayer server as player logged out");
-@@ -1937,7 +1944,7 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
+@@ -1937,7 +1943,7 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
              this.server.getPluginManager().callEvent(event);
  
              if (!event.isCancelled()) {
@@ -568,7 +566,7 @@ index 8b8b19c8afa32af136733bd7f77ed9417fab17fd..2eac381a825ed0edabd12816432f6d2d
      {
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java b/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
-index 43adfccd72c0629f5b93c735119fa4f84074d12b..f82bc7aa44e7299768aabf00fef7a995027ae1fe 100644
+index 43adfccd72c0629f5b93c735119fa4f84074d12b..5f39a8dff50d59cea70d6050f4e17101e38851e7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
 @@ -11,7 +11,7 @@ import org.bukkit.craftbukkit.util.CraftChatMessage;
@@ -580,7 +578,7 @@ index 43adfccd72c0629f5b93c735119fa4f84074d12b..f82bc7aa44e7299768aabf00fef7a995
  
      public CraftSign(final Block block) {
          super(block);
-@@ -20,40 +20,54 @@ public class CraftSign extends CraftBlockState implements Sign {
+@@ -20,30 +20,45 @@ public class CraftSign extends CraftBlockState implements Sign {
          sign = (TileEntitySign) world.getTileEntityAt(getX(), getY(), getZ());
          // Spigot start
          if (sign == null) {
@@ -613,10 +611,10 @@ index 43adfccd72c0629f5b93c735119fa4f84074d12b..f82bc7aa44e7299768aabf00fef7a995
      }
  
      public void setLine(int index, String line) throws IndexOutOfBoundsException {
-+        lines[index] = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(line); // PandaSpigot - Adventure
++    // PandaSpigot start - Adventure
++        lines[index] = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(line);
 +    }
 +
-+    // PandaSpigot start - Adventure
 +    @Override
 +    public java.util.List<net.kyori.adventure.text.Component> lines() {
 +        return java.util.Arrays.asList(lines);
@@ -629,12 +627,11 @@ index 43adfccd72c0629f5b93c735119fa4f84074d12b..f82bc7aa44e7299768aabf00fef7a995
 +
 +    @Override
 +    public void line(int index, net.kyori.adventure.text.Component line) throws IndexOutOfBoundsException {
++    // PandaSpigot end
          lines[index] = line;
      }
-+    // PandaSpigot end
  
-     @Override
-     public boolean update(boolean force, boolean applyPhysics) {
+@@ -52,8 +67,7 @@ public class CraftSign extends CraftBlockState implements Sign {
          boolean result = super.update(force, applyPhysics);
  
          if (result) {

--- a/patches/server/0114-Adventure-API.patch
+++ b/patches/server/0114-Adventure-API.patch
@@ -642,10 +642,10 @@ index 43adfccd72c0629f5b93c735119fa4f84074d12b..5f39a8dff50d59cea70d6050f4e17101
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 49477a0f4d237db75d869ed91dc5088f4b4385fe..a6c17a3fd08609eb427aaae8dcaced3f12e7837d 100644
+index 49477a0f4d237db75d869ed91dc5088f4b4385fe..75da9ba8a6333097c34bc38e680975f2ffb86043 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -194,6 +194,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -194,6 +194,25 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
                  footer == null ? null : new BaseComponent[]{footer});
      }
  
@@ -667,27 +667,11 @@ index 49477a0f4d237db75d869ed91dc5088f4b4385fe..a6c17a3fd08609eb427aaae8dcaced3f
 +
 +        getHandle().playerConnection.sendPacket(packet);
 +    }
-+
-+    @Override
-+    public void sendPlayerListHeader(final net.kyori.adventure.text.Component header) {
-+        PacketPlayOutPlayerListHeaderFooter packet = new PacketPlayOutPlayerListHeaderFooter();
-+        packet.adventure$header = header;
-+
-+        getHandle().playerConnection.sendPacket(packet);
-+    }
-+
-+    @Override
-+    public void sendPlayerListFooter(final net.kyori.adventure.text.Component footer) {
-+        PacketPlayOutPlayerListHeaderFooter packet = new PacketPlayOutPlayerListHeaderFooter();
-+        packet.adventure$footer = footer;
-+
-+        getHandle().playerConnection.sendPacket(packet);
-+    }
 +    // PandaSpigot end
  
      @Override
      public void setTitleTimes(int fadeInTicks, int stayTicks, int fadeOutTicks) {
-@@ -258,14 +293,34 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -258,14 +277,34 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  
@@ -724,7 +708,7 @@ index 49477a0f4d237db75d869ed91dc5088f4b4385fe..a6c17a3fd08609eb427aaae8dcaced3f
      }
  
      @Override
-@@ -286,6 +341,33 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -286,6 +325,33 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  
@@ -758,7 +742,7 @@ index 49477a0f4d237db75d869ed91dc5088f4b4385fe..a6c17a3fd08609eb427aaae8dcaced3f
      @Override
      public boolean equals(Object obj) {
          if (!(obj instanceof OfflinePlayer)) {
-@@ -314,6 +396,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -314,6 +380,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          getHandle().playerConnection.disconnect(message == null ? "" : message);
      }
  


### PR DESCRIPTION
This pull request adds native support for [Kyori Adventure](https://docs.advntr.dev/). This (hopefully) resolves #156. 
See #352 for history

<details>
<summary>Overview of changes</summary>

- #### General changes
   - CommandSender (and Player) can use Component and MiniMessage strings in messages
   - Permissible supports TriState values
   - Entity custom name supports Component
- #### Player changes
   - Send Tablist Headers / Footers, Titles using Adventure
   - Getters and Setters for displayName and playerListName with Component
   - Kick with Component
- #### Inventory and items
   - BookMeta title, author, and pages supports Component
   - ItemMeta displayName and lore supports Component
   - Inventory title supports Component
- #### Scoreboard 
   - Team displayName, prefix, and suffix support Component
- #### Events that now use Adventure
   - AsyncPlayerPreLoginEvent
   - PlayerDeathEvent
   - PlayerJoinEvent
   - PlayerKickEvent
   - PlayerLocaleChangeEvent
   - PlayerLoginEvent
   - PlayerPreLoginEvent
   - PlayerQuitEvent
   - ServerListPingEvent
   - SignChangeEvent

</details>
<details>
<summary>Unimplemented things that are still possible in 1.8</summary>

- Server Side Translatables
- Team ForwardingAudience
- Player#sendTitle/SignChange Component
- Rich message component support to configuration
- CommandBlock get/setName Component
- broadcast/broadcastMessage Component
- asHoverEvent() for ItemStack and Entity
- AsyncChatEvent with signed messages either removed or spoofed.
- Audience methods for Players
   - Opening books / BookMetaBuilder
   - Sending and clearing Resource packs
   - Playing sounds (and maybe stopping sounds for use with Via?)
   - showTitle
- CraftConsoleCommandSender sendMessage Component

</details>