### PR TITLE
Check for insertion in ChatModifier

### DIFF
--- a/patches/server/0116-Check-for-insertion-in-ChatModifier.patch
+++ b/patches/server/0116-Check-for-insertion-in-ChatModifier.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MasterDash5 <constant4337@molecularmail.com>
+Date: Mon, 10 Nov 2025 10:16:36 -0700
+Subject: [PATCH] Check for insertion in ChatModifier
+
+
+diff --git a/src/main/java/net/minecraft/server/ChatModifier.java b/src/main/java/net/minecraft/server/ChatModifier.java
+index 21f7e6ba239078ffd19898d32e6d0615df34f1e5..67bad2522f74e32baefd99e3c51167ad7b5511ca 100644
+--- a/src/main/java/net/minecraft/server/ChatModifier.java
++++ b/src/main/java/net/minecraft/server/ChatModifier.java
+@@ -135,7 +135,7 @@ public class ChatModifier {
+     }
+ 
+     public boolean g() {
+-        return this.c == null && this.d == null && this.f == null && this.e == null && this.g == null && this.b == null && this.h == null && this.i == null;
++        return this.c == null && this.d == null && this.f == null && this.e == null && this.g == null && this.b == null && this.h == null && this.i == null && this.j == null; // PandaSpigot - Check for insertion
+     }
+ 
+     public ChatClickable h() {


### PR DESCRIPTION
Mojang forgot to check if a component contains an insertion when serializing to JSON. This means if a component's style only contains an insertion, the serializer won't add the insertion to the JSON.

Insertion is missing:
 `/tellraw @a {"text":"test","insertion":"test"}`

Insertion is present:
`/tellraw @a {"text":"test","insertion":"test","color":"white"}`

This PR addds a check for insertion in `ChatModifier.g()`, which is used to check if a component contains any styling.
PandaAdventure also uses this serializer for NMS <-> Adventure, so the current Adventure implementation is also affected by this.