### PR TITLE
Fix end portal platform

### DIFF
--- a/patches/server/0121-Make-end-overworld-spawning-more-consistent-with-van.patch
+++ b/patches/server/0121-Make-end-overworld-spawning-more-consistent-with-van.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Make end->overworld spawning more consistent with vanilla
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index f61dce199e2d30d425e0d8af312406cc09baf018..fab74c7512fffa92605f88e8db0b6370f46ce9b9 100644
+index f61dce199e2d30d425e0d8af312406cc09baf018..3cc5fcdf65dac0f2ecf20b464de22fe7ce3ce6ce 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -680,7 +680,12 @@ public abstract class PlayerList {
@@ -22,12 +22,3 @@ index f61dce199e2d30d425e0d8af312406cc09baf018..fab74c7512fffa92605f88e8db0b6370
                  }
              } else {
                  // NORMAL <-> NETHER or NORMAL -> THE_END
-@@ -774,7 +779,7 @@ public abstract class PlayerList {
-             if (i == 1) {
-                 // use default NORMAL world spawn instead of target
-                 worldserver1 = this.server.worlds.get(0);
--                blockposition = worldserver1.getSpawn();
-+                blockposition = worldserver1.r(worldserver1.getSpawn()); // PandaSpigot - Make end->overworld spawning more consistent with vanilla
-             } else {
-                 blockposition = worldserver1.getDimensionSpawn();
-             }

--- a/patches/server/0121-Make-end-overworld-spawning-more-consistent-with-van.patch
+++ b/patches/server/0121-Make-end-overworld-spawning-more-consistent-with-van.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Make end->overworld spawning more consistent with vanilla
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index f61dce199e2d30d425e0d8af312406cc09baf018..3cc5fcdf65dac0f2ecf20b464de22fe7ce3ce6ce 100644
+index f61dce199e2d30d425e0d8af312406cc09baf018..fab74c7512fffa92605f88e8db0b6370f46ce9b9 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -680,7 +680,12 @@ public abstract class PlayerList {
@@ -22,3 +22,12 @@ index f61dce199e2d30d425e0d8af312406cc09baf018..3cc5fcdf65dac0f2ecf20b464de22fe7
                  }
              } else {
                  // NORMAL <-> NETHER or NORMAL -> THE_END
+@@ -774,7 +779,7 @@ public abstract class PlayerList {
+             if (i == 1) {
+                 // use default NORMAL world spawn instead of target
+                 worldserver1 = this.server.worlds.get(0);
+-                blockposition = worldserver1.getSpawn();
++                blockposition = worldserver1.r(worldserver1.getSpawn()); // PandaSpigot - Make end->overworld spawning more consistent with vanilla
+             } else {
+                 blockposition = worldserver1.getDimensionSpawn();
+             }

--- a/patches/server/0123-Fix-end-obsidian-platform-generation.patch
+++ b/patches/server/0123-Fix-end-obsidian-platform-generation.patch
@@ -44,7 +44,7 @@ index e9b9b66e25e747634f82cdfbc0306d33335db6f6..52c944a21e305701aa256de56e295160
              // CraftBukkit end
              this.lastSentExp = -1;
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index fab74c7512fffa92605f88e8db0b6370f46ce9b9..63262a86c0c226422a229e6d28597e7ab45b3313 100644
+index fab74c7512fffa92605f88e8db0b6370f46ce9b9..1505be500fb9a72998ed7daf4647742a1f9b672c 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -695,7 +695,7 @@ public abstract class PlayerList {
@@ -56,3 +56,12 @@ index fab74c7512fffa92605f88e8db0b6370f46ce9b9..63262a86c0c226422a229e6d28597e7a
  
          PlayerPortalEvent event = new PlayerPortalEvent(entityplayer.getBukkitEntity(), enter, exit, agent, cause);
          event.useTravelAgent(useTravelAgent);
+@@ -705,7 +705,7 @@ public abstract class PlayerList {
+         }
+ 
+         // PaperSpigot - Configurable end credits, if a plugin sets to use a travel agent even if the cause is an end portal, ignore it
+-        exit = cause != TeleportCause.END_PORTAL && event.useTravelAgent() ? event.getPortalTravelAgent().findOrCreate(event.getTo()) : event.getTo();
++        exit = (cause != TeleportCause.END_PORTAL || i == 1) && event.useTravelAgent() ? event.getPortalTravelAgent().findOrCreate(event.getTo()) : event.getTo(); // PandaSpigot - Use travel agent on overworld->end for platform generation
+         if (exit == null) {
+             return;
+         }

--- a/patches/server/0123-Fix-end-obsidian-platform-generation.patch
+++ b/patches/server/0123-Fix-end-obsidian-platform-generation.patch
@@ -1,0 +1,58 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MasterDash5 <constant4337@molecularmail.com>
+Date: Tue, 14 Apr 2026 22:33:24 -0600
+Subject: [PATCH] Fix end obsidian platform generation
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
+index e9b9b66e25e747634f82cdfbc0306d33335db6f6..52c944a21e305701aa256de56e2951604e28672a 100644
+--- a/src/main/java/net/minecraft/server/EntityPlayer.java
++++ b/src/main/java/net/minecraft/server/EntityPlayer.java
+@@ -536,10 +536,15 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+         boolean endPortal = this.dimension == 1 && i == 1;
+         if (endPortal) {
+             this.b((Statistic) AchievementList.D);
++            this.world.kill(this); // PandaSpigot - From below. Always kill for correct end exit.
+             if (!world.paperSpigotConfig.disableEndCredits) {
+-                this.world.kill(this);
++                //this.world.kill(this); // PandaSpigot - Move above
+                 this.viewingCredits = true;
+                 this.playerConnection.sendPacket(new PacketPlayOutGameStateChange(4, 0.0F));
++            // PandaSpigot start - Manually teleport because credits are skipped.
++            } else {
++                this.server.getPlayerList().changeDimension(this, 0, TeleportCause.END_PORTAL);
++            // PandaSpigot end
+             }
+         // PaperSpigot end
+         } else {
+@@ -559,12 +564,16 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+             } else {
+                 this.b((Statistic) AchievementList.y);
+             }
++        // PandaSpigot start - Don't always run this with credits skipped.
++        /*
+         }
+ 
+         // PaperSpigot start - Allow configurable end portal credits
+         if (!endPortal || world.paperSpigotConfig.disableEndCredits) {
++         */
+             // CraftBukkit start
+-            TeleportCause cause = (endPortal || (this.dimension == 1 || i == 1)) ? TeleportCause.END_PORTAL : TeleportCause.NETHER_PORTAL;
++            TeleportCause cause = this.dimension == 1 || i == 1 ? TeleportCause.END_PORTAL : TeleportCause.NETHER_PORTAL;
++        // PandaSpigot end
+             this.server.getPlayerList().changeDimension(this, i, cause);
+             // CraftBukkit end
+             this.lastSentExp = -1;
+diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
+index fab74c7512fffa92605f88e8db0b6370f46ce9b9..63262a86c0c226422a229e6d28597e7ab45b3313 100644
+--- a/src/main/java/net/minecraft/server/PlayerList.java
++++ b/src/main/java/net/minecraft/server/PlayerList.java
+@@ -695,7 +695,7 @@ public abstract class PlayerList {
+         }
+ 
+         TravelAgent agent = exit != null ? (TravelAgent) ((CraftWorld) exit.getWorld()).getHandle().getTravelAgent() : org.bukkit.craftbukkit.CraftTravelAgent.DEFAULT; // return arbitrary TA to compensate for implementation dependent plugins
+-        agent.setCanCreatePortal(cause != TeleportCause.END_PORTAL); // PaperSpigot - Configurable end credits, don't allow End Portals to create portals
++        //agent.setCanCreatePortal(cause != TeleportCause.END_PORTAL); // PaperSpigot - Configurable end credits, don't allow End Portals to create portals // PandaSpigot - The end obsidian platform is considered a "portal" and should be generated still.
+ 
+         PlayerPortalEvent event = new PlayerPortalEvent(entityplayer.getBukkitEntity(), enter, exit, agent, cause);
+         event.useTravelAgent(useTravelAgent);


### PR DESCRIPTION
This changes the skip credits logic so that end portals still follow vanilla logic, and generate the end platform. This fixes #389 

This also fixes entities that travel through end portals always teleporting to the exact spawn position.