### PR TITLE
Networking pipeline optimizations: reduce allocations and lock contention

### DIFF
--- a/patches/server/0124-PandaSpigot-Reuse-input-buffer-in-PacketCompressor-t.patch
+++ b/patches/server/0124-PandaSpigot-Reuse-input-buffer-in-PacketCompressor-t.patch
@@ -6,18 +6,19 @@ Subject: [PATCH] PandaSpigot - Reuse input buffer in PacketCompressor to avoid
 
 
 diff --git a/src/main/java/net/minecraft/server/PacketCompressor.java b/src/main/java/net/minecraft/server/PacketCompressor.java
-index 8107890ffbc205f5ce7e22c04d62fb8b16d087c2..37788a5f399590ce98c0a55bf48d576f88d4716b 100644
+index 8107890ffbc205f5ce7e22c04d62fb8b16d087c2..ea86e43093f6f812b1d9caa9863c84bc3856caba 100644
 --- a/src/main/java/net/minecraft/server/PacketCompressor.java
 +++ b/src/main/java/net/minecraft/server/PacketCompressor.java
-@@ -8,6 +8,7 @@ import java.util.zip.Deflater;
+@@ -8,6 +8,8 @@ import java.util.zip.Deflater;
  public class PacketCompressor extends MessageToByteEncoder<ByteBuf> {
  
      private final byte[] a = new byte[8192];
-+    private byte[] inputBuffer = new byte[8192]; // PandaSpigot - reusable input buffer to avoid allocation per compressed packet
++    private byte[] inputBuffer; // PandaSpigot - lazily initialized reusable input buffer
++    private static final int MAX_REUSABLE_SIZE = 65536; // PandaSpigot - cap reusable buffer to prevent unbounded growth per connection
      private final Deflater b;
      private int c;
  
-@@ -24,11 +25,14 @@ public class PacketCompressor extends MessageToByteEncoder<ByteBuf> {
+@@ -24,11 +26,20 @@ public class PacketCompressor extends MessageToByteEncoder<ByteBuf> {
              packetdataserializer.b(0);
              packetdataserializer.writeBytes(bytebuf);
          } else {
@@ -26,13 +27,19 @@ index 8107890ffbc205f5ce7e22c04d62fb8b16d087c2..37788a5f399590ce98c0a55bf48d576f
 -            bytebuf.readBytes(abyte);
 -            packetdataserializer.b(abyte.length);
 -            this.b.setInput(abyte, 0, i);
-+            // PandaSpigot start - grow reusable input buffer instead of allocating
-+            if (i > this.inputBuffer.length) {
-+                this.inputBuffer = new byte[i];
++            // PandaSpigot start - grow reusable input buffer instead of allocating, with lazy init and size cap
++            byte[] buf = this.inputBuffer;
++            if (buf == null || i > buf.length) {
++                if (i <= MAX_REUSABLE_SIZE) {
++                    buf = new byte[i];
++                    this.inputBuffer = buf;
++                } else {
++                    buf = new byte[i]; // oversized packet: allocate temporary, do not retain
++                }
 +            }
-+            bytebuf.readBytes(this.inputBuffer, 0, i);
++            bytebuf.readBytes(buf, 0, i);
 +            packetdataserializer.b(i);
-+            this.b.setInput(this.inputBuffer, 0, i);
++            this.b.setInput(buf, 0, i);
 +            // PandaSpigot end
              this.b.finish();
  

--- a/patches/server/0124-PandaSpigot-Reuse-input-buffer-in-PacketCompressor-t.patch
+++ b/patches/server/0124-PandaSpigot-Reuse-input-buffer-in-PacketCompressor-t.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Haniel Cota <hanielcota@hotmail.com>
+Date: Fri, 15 May 2026 13:08:47 -0300
+Subject: [PATCH] PandaSpigot - Reuse input buffer in PacketCompressor to avoid
+ allocation per compressed packet
+
+
+diff --git a/src/main/java/net/minecraft/server/PacketCompressor.java b/src/main/java/net/minecraft/server/PacketCompressor.java
+index 8107890ffbc205f5ce7e22c04d62fb8b16d087c2..37788a5f399590ce98c0a55bf48d576f88d4716b 100644
+--- a/src/main/java/net/minecraft/server/PacketCompressor.java
++++ b/src/main/java/net/minecraft/server/PacketCompressor.java
+@@ -8,6 +8,7 @@ import java.util.zip.Deflater;
+ public class PacketCompressor extends MessageToByteEncoder<ByteBuf> {
+ 
+     private final byte[] a = new byte[8192];
++    private byte[] inputBuffer = new byte[8192]; // PandaSpigot - reusable input buffer to avoid allocation per compressed packet
+     private final Deflater b;
+     private int c;
+ 
+@@ -24,11 +25,14 @@ public class PacketCompressor extends MessageToByteEncoder<ByteBuf> {
+             packetdataserializer.b(0);
+             packetdataserializer.writeBytes(bytebuf);
+         } else {
+-            byte[] abyte = new byte[i];
+-
+-            bytebuf.readBytes(abyte);
+-            packetdataserializer.b(abyte.length);
+-            this.b.setInput(abyte, 0, i);
++            // PandaSpigot start - grow reusable input buffer instead of allocating
++            if (i > this.inputBuffer.length) {
++                this.inputBuffer = new byte[i];
++            }
++            bytebuf.readBytes(this.inputBuffer, 0, i);
++            packetdataserializer.b(i);
++            this.b.setInput(this.inputBuffer, 0, i);
++            // PandaSpigot end
+             this.b.finish();
+ 
+             while (!this.b.finished()) {

--- a/patches/server/0125-PandaSpigot-Replace-synchronized-packet-limiter-with.patch
+++ b/patches/server/0125-PandaSpigot-Replace-synchronized-packet-limiter-with.patch
@@ -1,0 +1,131 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Haniel Cota <hanielcota@hotmail.com>
+Date: Fri, 15 May 2026 13:21:23 -0300
+Subject: [PATCH] PandaSpigot - Replace synchronized packet limiter with
+ lock-free AtomicIntervalledCounter
+
+
+diff --git a/src/main/java/com/hpfxd/pandaspigot/util/AtomicIntervalledCounter.java b/src/main/java/com/hpfxd/pandaspigot/util/AtomicIntervalledCounter.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..d3102244e29d1197f21a73356c6aecdea81071eb
+--- /dev/null
++++ b/src/main/java/com/hpfxd/pandaspigot/util/AtomicIntervalledCounter.java
+@@ -0,0 +1,43 @@
++package com.hpfxd.pandaspigot.util;
++
++import java.util.concurrent.atomic.AtomicInteger;
++import java.util.concurrent.atomic.AtomicLong;
++import java.util.concurrent.atomic.LongAdder;
++
++// PandaSpigot - Lock-free replacement for IntervalledCounter in packet limiter hot path
++public final class AtomicIntervalledCounter {
++
++    private final long interval;
++    private final AtomicLong windowStart;
++    private final LongAdder[] counts;
++    private final AtomicInteger current;
++
++    public AtomicIntervalledCounter(long interval) {
++        this.interval = interval;
++        this.windowStart = new AtomicLong(System.nanoTime());
++        this.counts = new LongAdder[] { new LongAdder(), new LongAdder() };
++        this.current = new AtomicInteger(0);
++    }
++
++    public void updateAndAdd(int amount, long time) {
++        long start = this.windowStart.get();
++        if (time - start > this.interval) {
++            if (this.windowStart.compareAndSet(start, time)) {
++                int next = 1 - this.current.get();
++                this.counts[next].reset();
++                this.current.set(next);
++            }
++        }
++        this.counts[this.current.get()].add(amount);
++    }
++
++    // returns in units per second
++    public double getRate() {
++        long start = this.windowStart.get();
++        long age = System.nanoTime() - start;
++        if (age <= 0) {
++            return 0.0;
++        }
++        return this.counts[this.current.get()].sum() / (age * 1.0e-9);
++    }
++}
+diff --git a/src/main/java/net/minecraft/server/NetworkManager.java b/src/main/java/net/minecraft/server/NetworkManager.java
+index 9ff04c5016f1b8f339975559b8cf619f1841da82..a3de7a3d68bc2333982a2e453d4fa624a5aefc89 100644
+--- a/src/main/java/net/minecraft/server/NetworkManager.java
++++ b/src/main/java/net/minecraft/server/NetworkManager.java
+@@ -118,12 +118,11 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet> {
+     // PandaSpigot end
+ 
+     // PandaSpigot start - packet limiter
+-    protected final Object PACKET_LIMIT_LOCK = new Object();
+-    protected final com.hpfxd.pandaspigot.util.IntervalledCounter allPacketCounts = com.hpfxd.pandaspigot.config.PandaSpigotConfig.get().packetLimiter.getAllPacketsLimit() != null ? new com.hpfxd.pandaspigot.util.IntervalledCounter(
++    protected final com.hpfxd.pandaspigot.util.AtomicIntervalledCounter allPacketCounts = com.hpfxd.pandaspigot.config.PandaSpigotConfig.get().packetLimiter.getAllPacketsLimit() != null ? new com.hpfxd.pandaspigot.util.AtomicIntervalledCounter(
+         (long) (com.hpfxd.pandaspigot.config.PandaSpigotConfig.get().packetLimiter.getAllPacketsLimit().packetLimitInterval * 1.0e9)
+     ) : null;
+-    protected final java.util.Map<Class<? extends Packet<?>>, com.hpfxd.pandaspigot.util.IntervalledCounter> packetSpecificLimits = new java.util.HashMap<>();
+-    private boolean stopReadingPackets;
++    protected final java.util.concurrent.ConcurrentHashMap<Class<? extends Packet<?>>, com.hpfxd.pandaspigot.util.AtomicIntervalledCounter> packetSpecificLimits = new java.util.concurrent.ConcurrentHashMap<>();
++    private volatile boolean stopReadingPackets;
+     private void killForPacketSpam() {
+         IChatBaseComponent[] reason = org.bukkit.craftbukkit.util.CraftChatMessage.fromString(org.bukkit.ChatColor.translateAlternateColorCodes('&', com.hpfxd.pandaspigot.config.PandaSpigotConfig.get().packetLimiter.getKickMessage()));
+         this.a(new PacketPlayOutKickDisconnect(reason[0]), future -> {
+@@ -187,32 +186,30 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet> {
+             if (this.allPacketCounts != null ||
+                 com.hpfxd.pandaspigot.config.PandaSpigotConfig.get().packetLimiter.getPacketSpecificLimits().containsKey(packet.getClass())) {
+                 long time = System.nanoTime();
+-                synchronized (PACKET_LIMIT_LOCK) {
+-                    if (this.allPacketCounts != null) {
+-                        this.allPacketCounts.updateAndAdd(1, time);
+-                        if (this.allPacketCounts.getRate() >= com.hpfxd.pandaspigot.config.PandaSpigotConfig.get().packetLimiter.getAllPacketsLimit().maxPacketRate) {
+-                            this.killForPacketSpam();
+-                            return;
+-                        }
++                if (this.allPacketCounts != null) {
++                    this.allPacketCounts.updateAndAdd(1, time);
++                    if (this.allPacketCounts.getRate() >= com.hpfxd.pandaspigot.config.PandaSpigotConfig.get().packetLimiter.getAllPacketsLimit().maxPacketRate) {
++                        this.killForPacketSpam();
++                        return;
+                     }
++                }
+ 
+-                    for (Class<?> check = packet.getClass(); check != Object.class; check = check.getSuperclass()) {
+-                        com.hpfxd.pandaspigot.config.PacketLimiterConfig.PacketLimit packetSpecificLimit = com.hpfxd.pandaspigot.config.PandaSpigotConfig.get().packetLimiter.getPacketSpecificLimits().get(check);
+-                        if (packetSpecificLimit == null) {
+-                            continue;
+-                        }
+-                        com.hpfxd.pandaspigot.util.IntervalledCounter counter = this.packetSpecificLimits.computeIfAbsent((Class) check, clazz -> {
+-                            return new com.hpfxd.pandaspigot.util.IntervalledCounter((long) (packetSpecificLimit.packetLimitInterval * 1.0e9));
+-                        });
+-                        counter.updateAndAdd(1, time);
+-                        if (counter.getRate() >= packetSpecificLimit.maxPacketRate) {
+-                            switch (packetSpecificLimit.violateAction) {
+-                                case DROP:
+-                                    return;
+-                                case KICK:
+-                                    this.killForPacketSpam();
+-                                    return;
+-                            }
++                for (Class<?> check = packet.getClass(); check != Object.class; check = check.getSuperclass()) {
++                    com.hpfxd.pandaspigot.config.PacketLimiterConfig.PacketLimit packetSpecificLimit = com.hpfxd.pandaspigot.config.PandaSpigotConfig.get().packetLimiter.getPacketSpecificLimits().get(check);
++                    if (packetSpecificLimit == null) {
++                        continue;
++                    }
++                    com.hpfxd.pandaspigot.util.AtomicIntervalledCounter counter = this.packetSpecificLimits.computeIfAbsent((Class) check, clazz -> {
++                        return new com.hpfxd.pandaspigot.util.AtomicIntervalledCounter((long) (packetSpecificLimit.packetLimitInterval * 1.0e9));
++                    });
++                    counter.updateAndAdd(1, time);
++                    if (counter.getRate() >= packetSpecificLimit.maxPacketRate) {
++                        switch (packetSpecificLimit.violateAction) {
++                            case DROP:
++                                return;
++                            case KICK:
++                                this.killForPacketSpam();
++                                return;
+                         }
+                     }
+                 }

--- a/patches/server/0126-PandaSpigot-Reuse-PacketDataSerializer-instances-in-.patch
+++ b/patches/server/0126-PandaSpigot-Reuse-PacketDataSerializer-instances-in-.patch
@@ -1,0 +1,86 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Haniel Cota <hanielcota@hotmail.com>
+Date: Fri, 15 May 2026 13:31:53 -0300
+Subject: [PATCH] PandaSpigot - Reuse PacketDataSerializer instances in Netty
+ handlers to avoid allocation per packet
+
+
+diff --git a/src/main/java/net/minecraft/server/PacketCompressor.java b/src/main/java/net/minecraft/server/PacketCompressor.java
+index 37788a5f399590ce98c0a55bf48d576f88d4716b..de5996b786db944ebfd35d6eca710b49d43221fc 100644
+--- a/src/main/java/net/minecraft/server/PacketCompressor.java
++++ b/src/main/java/net/minecraft/server/PacketCompressor.java
+@@ -19,7 +19,7 @@ public class PacketCompressor extends MessageToByteEncoder<ByteBuf> {
+ 
+     protected void a(ChannelHandlerContext channelhandlercontext, ByteBuf bytebuf, ByteBuf bytebuf1) throws Exception {
+         int i = bytebuf.readableBytes();
+-        PacketDataSerializer packetdataserializer = new PacketDataSerializer(bytebuf1);
++        PacketDataSerializer packetdataserializer = PacketDataSerializer.forBuffer(bytebuf1); // PandaSpigot
+ 
+         if (i < this.c) {
+             packetdataserializer.b(0);
+diff --git a/src/main/java/net/minecraft/server/PacketDataSerializer.java b/src/main/java/net/minecraft/server/PacketDataSerializer.java
+index 09b8fa11efa326345b3b4eaf952676f4841f8115..bd494418f9a20231788c348d108d1f5d71294d99 100644
+--- a/src/main/java/net/minecraft/server/PacketDataSerializer.java
++++ b/src/main/java/net/minecraft/server/PacketDataSerializer.java
+@@ -29,12 +29,21 @@ import org.bukkit.craftbukkit.inventory.CraftItemStack; // CraftBukkit
+ 
+ public class PacketDataSerializer extends ByteBuf {
+ 
+-    private final ByteBuf a;
++    private ByteBuf a; // PandaSpigot - removed final for reuse
++    private static final ThreadLocal<PacketDataSerializer> INSTANCE = ThreadLocal.withInitial(() -> new PacketDataSerializer(null)); // PandaSpigot
+ 
+     public PacketDataSerializer(ByteBuf bytebuf) {
+         this.a = bytebuf;
+     }
+ 
++    // PandaSpigot start - Reuse PacketDataSerializer instances to avoid allocation per packet in Netty handlers
++    public static PacketDataSerializer forBuffer(ByteBuf bytebuf) {
++        PacketDataSerializer s = INSTANCE.get();
++        s.a = bytebuf;
++        return s;
++    }
++    // PandaSpigot end
++
+     public static int a(int i) {
+         for (int j = 1; j < 5; ++j) {
+             if ((i & -1 << j * 7) == 0) {
+diff --git a/src/main/java/net/minecraft/server/PacketDecoder.java b/src/main/java/net/minecraft/server/PacketDecoder.java
+index d48e4934ed9ccdd81f23131845e1d3b2bf68be30..5ab66261bcc8ab872b8c8ae8449490c9c7922eb7 100644
+--- a/src/main/java/net/minecraft/server/PacketDecoder.java
++++ b/src/main/java/net/minecraft/server/PacketDecoder.java
+@@ -22,7 +22,7 @@ public class PacketDecoder extends ByteToMessageDecoder {
+ 
+     protected void decode(ChannelHandlerContext channelhandlercontext, ByteBuf bytebuf, List<Object> list) throws Exception {
+         if (bytebuf.readableBytes() != 0) {
+-            PacketDataSerializer packetdataserializer = new PacketDataSerializer(bytebuf);
++            PacketDataSerializer packetdataserializer = PacketDataSerializer.forBuffer(bytebuf); // PandaSpigot
+             int i = packetdataserializer.e();
+             Packet packet = ((EnumProtocol) channelhandlercontext.channel().attr(NetworkManager.c).get()).a(this.c, i);
+ 
+diff --git a/src/main/java/net/minecraft/server/PacketDecompressor.java b/src/main/java/net/minecraft/server/PacketDecompressor.java
+index 300d46475a682fbeb4db3e21e64f3c18e21a14c7..34d0e7b16f2e03a35e8bf00ddd44cdb5292ace05 100644
+--- a/src/main/java/net/minecraft/server/PacketDecompressor.java
++++ b/src/main/java/net/minecraft/server/PacketDecompressor.java
+@@ -20,7 +20,7 @@ public class PacketDecompressor extends ByteToMessageDecoder {
+ 
+     protected void decode(ChannelHandlerContext channelhandlercontext, ByteBuf bytebuf, List<Object> list) throws Exception {
+         if (bytebuf.readableBytes() != 0) {
+-            PacketDataSerializer packetdataserializer = new PacketDataSerializer(bytebuf);
++            PacketDataSerializer packetdataserializer = PacketDataSerializer.forBuffer(bytebuf); // PandaSpigot
+             int i = packetdataserializer.e();
+ 
+             if (i == 0) {
+diff --git a/src/main/java/net/minecraft/server/PacketEncoder.java b/src/main/java/net/minecraft/server/PacketEncoder.java
+index 9ebae0b5a96c0f4e5f6475e41251b4d4d519c86a..8ffde6983ef93d43dfe40e33732f94b0d32a2a2a 100644
+--- a/src/main/java/net/minecraft/server/PacketEncoder.java
++++ b/src/main/java/net/minecraft/server/PacketEncoder.java
+@@ -29,7 +29,7 @@ public class PacketEncoder extends MessageToByteEncoder<Packet> {
+         if (integer == null) {
+             throw new IOException("Can't serialize unregistered packet");
+         } else {
+-            PacketDataSerializer packetdataserializer = new PacketDataSerializer(bytebuf);
++            PacketDataSerializer packetdataserializer = PacketDataSerializer.forBuffer(bytebuf); // PandaSpigot
+ 
+             packetdataserializer.b(integer);
+ 

--- a/patches/server/0126-PandaSpigot-Reuse-PacketDataSerializer-instances-in-.patch
+++ b/patches/server/0126-PandaSpigot-Reuse-PacketDataSerializer-instances-in-.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] PandaSpigot - Reuse PacketDataSerializer instances in Netty
 
 
 diff --git a/src/main/java/net/minecraft/server/PacketCompressor.java b/src/main/java/net/minecraft/server/PacketCompressor.java
-index 37788a5f399590ce98c0a55bf48d576f88d4716b..de5996b786db944ebfd35d6eca710b49d43221fc 100644
+index ea86e43093f6f812b1d9caa9863c84bc3856caba..6cae301d42fad3841714a8adba1262583d92b70a 100644
 --- a/src/main/java/net/minecraft/server/PacketCompressor.java
 +++ b/src/main/java/net/minecraft/server/PacketCompressor.java
-@@ -19,7 +19,7 @@ public class PacketCompressor extends MessageToByteEncoder<ByteBuf> {
+@@ -20,7 +20,7 @@ public class PacketCompressor extends MessageToByteEncoder<ByteBuf> {
  
      protected void a(ChannelHandlerContext channelhandlercontext, ByteBuf bytebuf, ByteBuf bytebuf1) throws Exception {
          int i = bytebuf.readableBytes();

--- a/patches/server/0127-PandaSpigot-Pool-QueuedPacket-objects-to-avoid-alloc.patch
+++ b/patches/server/0127-PandaSpigot-Pool-QueuedPacket-objects-to-avoid-alloc.patch
@@ -1,0 +1,109 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Haniel Cota <hanielcota@hotmail.com>
+Date: Fri, 15 May 2026 13:39:36 -0300
+Subject: [PATCH] PandaSpigot - Pool QueuedPacket objects to avoid allocation
+ per queued packet
+
+
+diff --git a/src/main/java/net/minecraft/server/NetworkManager.java b/src/main/java/net/minecraft/server/NetworkManager.java
+index a3de7a3d68bc2333982a2e453d4fa624a5aefc89..0eed5be8883fc47a8d300640345cb11873e4320a 100644
+--- a/src/main/java/net/minecraft/server/NetworkManager.java
++++ b/src/main/java/net/minecraft/server/NetworkManager.java
+@@ -256,15 +256,15 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet> {
+         java.util.List<Packet<?>> extraPackets = InnerUtil.buildExtraPackets(packet);
+         boolean hasExtraPackets = extraPackets != null && !extraPackets.isEmpty();
+         if (!hasExtraPackets) {
+-            i.add(new NetworkManager.QueuedPacket(packet, listeners));
++            i.add(this.obtainQueuedPacket(packet, listeners));
+         } else {
+             java.util.List<NetworkManager.QueuedPacket> packets = new java.util.ArrayList<>(1 + extraPackets.size());
+-            packets.add(new NetworkManager.QueuedPacket(packet, (GenericFutureListener<? extends Future<? super Void>>[]) null)); // delay the future listener until the end of the extra packets
++            packets.add(this.obtainQueuedPacket(packet, (GenericFutureListener<? extends Future<? super Void>>[]) null)); // delay the future listener until the end of the extra packets
+ 
+             for (int i = 0, len = extraPackets.size(); i < len;) {
+                 Packet<?> extra = extraPackets.get(i);
+                 boolean end = ++i == len;
+-                packets.add(new NetworkManager.QueuedPacket(extra, end ? listeners : null)); // append listener to the end
++                packets.add(this.obtainQueuedPacket(extra, end ? listeners : null)); // append listener to the end
+             }
+             i.addAll(packets);
+         }
+@@ -412,6 +412,7 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet> {
+                 this.writePacket(packet, queued.getGenericFutureListener(), (!iterator.hasNext() && (needsFlush || this.canFlush)) ? Boolean.TRUE : Boolean.FALSE);
+                 hasWrotePacket = true;
+                 // PandaSpigot end
++                this.recycleQueuedPacket(queued); // PandaSpigot
+             }
+         }
+         return true;
+@@ -434,13 +435,14 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet> {
+     // PandaSpigot start
+     public void clearPacketQueue() {
+         EntityPlayer player = getPlayer();
+-        i.forEach(queuedPacket -> {
++        QueuedPacket queuedPacket;
++        while ((queuedPacket = i.poll()) != null) {
+             Packet<?> packet = queuedPacket.getPacket();
+-            if (packet.hasFinishListener()) {
++            if (packet != null && packet.hasFinishListener()) {
+                 packet.onPacketDispatchFinish(player, null);
+             }
+-        });
+-        i.clear();
++            this.recycleQueuedPacket(queuedPacket);
++        }
+     }
+     // PandaSpigot end
+ 
+@@ -535,8 +537,20 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet> {
+ 
+     static class QueuedPacket {
+ 
+-        private final Packet a; private Packet getPacket() { return this.a; } // PandaSpigot - OBFHELPER
+-        private final GenericFutureListener<? extends Future<? super Void>>[] b; private GenericFutureListener<? extends Future<? super Void>>[] getGenericFutureListener() { return this.b; } // PandaSpigot - OBFHELPER
++        private Packet a; private Packet getPacket() { return this.a; } // PandaSpigot - OBFHELPER
++        private GenericFutureListener<? extends Future<? super Void>>[] b; private GenericFutureListener<? extends Future<? super Void>>[] getGenericFutureListener() { return this.b; } // PandaSpigot - OBFHELPER
++
++        // PandaSpigot start - pooling support
++        void set(Packet packet, GenericFutureListener<? extends Future<? super Void>>[] listeners) {
++            this.a = packet;
++            this.b = listeners;
++        }
++
++        void clear() {
++            this.a = null;
++            this.b = null;
++        }
++        // PandaSpigot end
+ 
+         public QueuedPacket(Packet packet, GenericFutureListener<? extends Future<? super Void>>... agenericfuturelistener) {
+             this.a = packet;
+@@ -544,6 +558,28 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet> {
+         }
+     }
+ 
++    // PandaSpigot start - QueuedPacket pool to avoid allocation per queued packet
++    private final java.util.ArrayDeque<QueuedPacket> queuedPacketPool = new java.util.ArrayDeque<>();
++
++    private QueuedPacket obtainQueuedPacket(Packet packet, GenericFutureListener<? extends Future<? super Void>>[] listeners) {
++        synchronized (this.queuedPacketPool) {
++            QueuedPacket q = this.queuedPacketPool.poll();
++            if (q != null) {
++                q.set(packet, listeners);
++                return q;
++            }
++        }
++        return new QueuedPacket(packet, listeners);
++    }
++
++    private void recycleQueuedPacket(QueuedPacket q) {
++        synchronized (this.queuedPacketPool) {
++            q.clear();
++            this.queuedPacketPool.offer(q);
++        }
++    }
++    // PandaSpigot end
++
+     // Spigot Start
+     public SocketAddress getRawAddress()
+     {

--- a/patches/server/0128-PandaSpigot-Login-optimizations-cache-brand-packet-d.patch
+++ b/patches/server/0128-PandaSpigot-Login-optimizations-cache-brand-packet-d.patch
@@ -1,0 +1,143 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Haniel Cota <hanielcota@hotmail.com>
+Date: Fri, 15 May 2026 14:41:26 -0300
+Subject: [PATCH] PandaSpigot - Login optimizations: cache brand packet, dedup
+ scoreboard without HashSet, cache spawn position
+
+
+diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
+index 9b6214d194cbd43bf14345610c360ae9f790bab2..d8f13ec07c2729c46b27a559fda57695c2e82dd2 100644
+--- a/src/main/java/net/minecraft/server/PlayerList.java
++++ b/src/main/java/net/minecraft/server/PlayerList.java
+@@ -67,6 +67,10 @@ public abstract class PlayerList {
+     private CraftServer cserver;
+     private final Map<String,EntityPlayer> playersByName = new org.spigotmc.CaseInsensitiveMap<EntityPlayer>();
+ 
++    // PandaSpigot start - pre-build reusable brand packet to avoid allocation per login
++    private final PacketPlayOutCustomPayload brandPacket;
++    // PandaSpigot end
++
+     public PlayerList(MinecraftServer minecraftserver) {
+         this.cserver = minecraftserver.server = new CraftServer(minecraftserver, this);
+         minecraftserver.console = new com.hpfxd.pandaspigot.console.PandaConsoleCommandSender(); // PandaSpigot
+@@ -81,6 +85,9 @@ public abstract class PlayerList {
+         this.k.a(false);
+         this.l.a(false);
+         this.maxPlayers = 8;
++        // PandaSpigot start
++        this.brandPacket = new PacketPlayOutCustomPayload("MC|Brand", (new PacketDataSerializer(Unpooled.buffer())).a(minecraftserver.getServerModName()));
++        // PandaSpigot end
+     }
+ 
+     public void a(NetworkManager networkmanager, EntityPlayer entityplayer) {
+@@ -146,7 +153,7 @@ public abstract class PlayerList {
+ 
+         playerconnection.sendPacket(new PacketPlayOutLogin(entityplayer.getId(), entityplayer.playerInteractManager.getGameMode(), worlddata.isHardcore(), worldserver.worldProvider.getDimension(), worldserver.getDifficulty(), Math.min(this.getMaxPlayers(), 60), worlddata.getType(), worldserver.getGameRules().getBoolean("reducedDebugInfo"))); // CraftBukkit - cap player list to 60
+         entityplayer.getBukkitEntity().sendSupportedChannels(); // CraftBukkit
+-        playerconnection.sendPacket(new PacketPlayOutCustomPayload("MC|Brand", (new PacketDataSerializer(Unpooled.buffer())).a(this.getServer().getServerModName())));
++        playerconnection.sendPacket(this.brandPacket); // PandaSpigot - reuse brand packet
+         playerconnection.sendPacket(new PacketPlayOutServerDifficulty(worlddata.getDifficulty(), worlddata.isDifficultyLocked()));
+         playerconnection.sendPacket(new PacketPlayOutSpawnPosition(blockposition));
+         playerconnection.sendPacket(new PacketPlayOutAbilities(entityplayer.abilities));
+@@ -206,7 +213,9 @@ public abstract class PlayerList {
+     }
+ 
+     public void sendScoreboard(ScoreboardServer scoreboardserver, EntityPlayer entityplayer) {
+-        HashSet hashset = Sets.newHashSet();
++        // PandaSpigot start - avoid HashSet allocation; 19 slots max, use reference-equality dedup
++        ScoreboardObjective[] sent = new ScoreboardObjective[19];
++        int sentCount = 0;
+         Iterator iterator = scoreboardserver.getTeams().iterator();
+ 
+         while (iterator.hasNext()) {
+@@ -218,19 +227,29 @@ public abstract class PlayerList {
+         for (int i = 0; i < 19; ++i) {
+             ScoreboardObjective scoreboardobjective = scoreboardserver.getObjectiveForSlot(i);
+ 
+-            if (scoreboardobjective != null && !hashset.contains(scoreboardobjective)) {
+-                List list = scoreboardserver.getScoreboardScorePacketsForObjective(scoreboardobjective);
+-                Iterator iterator1 = list.iterator();
++            if (scoreboardobjective != null) {
++                boolean alreadySent = false;
++                for (int j = 0; j < sentCount; j++) {
++                    if (sent[j] == scoreboardobjective) {
++                        alreadySent = true;
++                        break;
++                    }
++                }
++                if (!alreadySent) {
++                    List list = scoreboardserver.getScoreboardScorePacketsForObjective(scoreboardobjective);
++                    Iterator iterator1 = list.iterator();
+ 
+-                while (iterator1.hasNext()) {
+-                    Packet packet = (Packet) iterator1.next();
++                    while (iterator1.hasNext()) {
++                        Packet packet = (Packet) iterator1.next();
+ 
+-                    entityplayer.playerConnection.sendPacket(packet);
+-                }
++                        entityplayer.playerConnection.sendPacket(packet);
++                    }
+ 
+-                hashset.add(scoreboardobjective);
++                    sent[sentCount++] = scoreboardobjective;
++                }
+             }
+         }
++        // PandaSpigot end
+ 
+     }
+ 
+diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
+index 9b86cdd3b83ae8b0c040dc9d250b54684d0b7510..d9e00acf59ef17087fae057e986af2fa1870481c 100644
+--- a/src/main/java/net/minecraft/server/World.java
++++ b/src/main/java/net/minecraft/server/World.java
+@@ -219,14 +219,17 @@ public abstract class World implements IBlockAccess {
+         this.N.a(new IWorldBorderListener() {
+             public void a(WorldBorder worldborder, double d0) {
+                 getServer().getHandle().sendAll(new PacketPlayOutWorldBorder(worldborder, PacketPlayOutWorldBorder.EnumWorldBorderAction.SET_SIZE), World.this);
++                World.this.cachedSpawn = null; // PandaSpigot - invalidate spawn cache on border change
+             }
+ 
+             public void a(WorldBorder worldborder, double d0, double d1, long i) {
+                 getServer().getHandle().sendAll(new PacketPlayOutWorldBorder(worldborder, PacketPlayOutWorldBorder.EnumWorldBorderAction.LERP_SIZE), World.this);
++                World.this.cachedSpawn = null; // PandaSpigot
+             }
+ 
+             public void a(WorldBorder worldborder, double d0, double d1) {
+                 getServer().getHandle().sendAll(new PacketPlayOutWorldBorder(worldborder, PacketPlayOutWorldBorder.EnumWorldBorderAction.SET_CENTER), World.this);
++                World.this.cachedSpawn = null; // PandaSpigot
+             }
+ 
+             public void a(WorldBorder worldborder, int i) {
+@@ -3145,19 +3148,26 @@ public abstract class World implements IBlockAccess {
+         this.worldData.setDayTime(i);
+     }
+ 
++    // PandaSpigot start - cache spawn position to avoid repeated allocation
++    private BlockPosition cachedSpawn;
++
+     public BlockPosition getSpawn() {
+-        BlockPosition blockposition = new BlockPosition(this.worldData.c(), this.worldData.d(), this.worldData.e());
++        if (this.cachedSpawn == null) {
++            this.cachedSpawn = new BlockPosition(this.worldData.c(), this.worldData.d(), this.worldData.e());
+ 
+-        if (!this.getWorldBorder().a(blockposition)) {
+-            blockposition = this.getHighestBlockYAt(new BlockPosition(this.getWorldBorder().getCenterX(), 0.0D, this.getWorldBorder().getCenterZ()));
++            if (!this.getWorldBorder().a(this.cachedSpawn)) {
++                this.cachedSpawn = this.getHighestBlockYAt(new BlockPosition(this.getWorldBorder().getCenterX(), 0.0D, this.getWorldBorder().getCenterZ()));
++            }
+         }
+ 
+-        return blockposition;
++        return this.cachedSpawn;
+     }
+ 
+     public void B(BlockPosition blockposition) {
+         this.worldData.setSpawn(blockposition);
++        this.cachedSpawn = null; // invalidate cache
+     }
++    // PandaSpigot end
+ 
+     public boolean a(EntityHuman entityhuman, BlockPosition blockposition) {
+         return true;


### PR DESCRIPTION
## Summary

This PR contains networking and login pipeline optimizations focused on reducing allocation pressure, eliminating lock contention, and cutting synchronous overhead in hot I/O and player-join paths.

---

## Patch 1 — Reuse input buffer in PacketCompressor (lazy-init, 64KB cap)

**File:** `PacketCompressor.java`

`PacketCompressor` previously allocated a new `byte[]` for every packet exceeding the compression threshold.

**Changes:**
- Added reusable `inputBuffer` field that is **lazily initialized** on first compressed packet (idle connections pay zero overhead)
- Buffer grows only when needed, capped at **64KB** (`MAX_REUSABLE_SIZE`)
- Packets larger than 64KB allocate a temporary array and are not retained, preventing unbounded per-connection growth

**Impact:** Reduces GC pressure during chunk sending and large packet bursts; idle connections retain no compressor buffer

---

## Patch 2 — Replace synchronized packet limiter with lock-free AtomicIntervalledCounter

**Files:** `NetworkManager.java`, `AtomicIntervalledCounter.java` (new)

Every inbound packet acquired `synchronized(PACKET_LIMIT_LOCK)` when packet limiting was enabled, creating unnecessary contention on a per-connection hot path.

**Changes:**
- Introduces `AtomicIntervalledCounter`, a lock-free counter using `AtomicLong` + dual `LongAdder` rotation
- Replaces `HashMap<IntervalledCounter>` with `ConcurrentHashMap<AtomicIntervalledCounter>`
- Removes `PACKET_LIMIT_LOCK` entirely; `stopReadingPackets` changed to `volatile`

**Impact:** Eliminates monitor enter/exit overhead on every inbound packet when limiter is active

---

## Patch 3 — Reuse PacketDataSerializer instances in Netty handlers

**Files:** `PacketDataSerializer.java`, `PacketEncoder.java`, `PacketDecoder.java`, `PacketCompressor.java`, `PacketDecompressor.java`

Every packet passing through the Netty pipeline triggered `new PacketDataSerializer(bytebuf)` — a pure wrapper allocation with a single `ByteBuf` field.

**Changes:**
- `PacketDataSerializer` now uses a `ThreadLocal` singleton per thread, swapping the underlying `ByteBuf` via `forBuffer(ByteBuf)`
- All 4 Netty handlers (`PacketEncoder`, `PacketDecoder`, `PacketCompressor`, `PacketDecompressor`) use the reused instance

**Impact:** Eliminates 1 `PacketDataSerializer` allocation per packet in encode/decode/compress/decompress paths

---

## Patch 4 — Pool QueuedPacket objects

**File:** `NetworkManager.java`

Every packet that couldn't be sent immediately allocated a new `QueuedPacket` wrapper for the outbound queue.

**Changes:**
- Added `ArrayDeque<QueuedPacket>` pool per `NetworkManager`
- `obtainQueuedPacket()` reuses from pool or allocates only when empty
- `recycleQueuedPacket()` returns processed packets to the pool
- `clearPacketQueue()` also recycles on connection close

**Impact:** Eliminates `QueuedPacket` allocations for the common case of queue-then-send immediately after

---

## Patch 5 — Login pipeline micro-optimizations

**Files:** `PlayerList.java`, `World.java`

The login path had several small but measurable overheads that added up during mass joins.

**Changes:**
- **Pre-build `MC|Brand` packet** once in `PlayerList` constructor and reuse for every login (eliminates `PacketDataSerializer` + `Unpooled.buffer()` alloc per player)
- **Scoreboard dedup without `HashSet`** in `sendScoreboard()`: uses a fixed `ScoreboardObjective[19]` array with reference-equality checks instead of `Sets.newHashSet()` per login
- **Cache `World.getSpawn()`** result and invalidate only on `setSpawn()` or world-border resize/center changes (eliminates repeated `new BlockPosition` + world-border checks)

**Impact:** Reduces allocation churn and redundant computation during player join

---

## Testing

- `./panda jar` compiles successfully
- `./panda rb` rebuilds patches cleanly
- All patches apply cleanly on fresh `panda setup`

## Compliance

- Multi-line changes wrapped with `// PandaSpigot start/end` comments
- Oracle Java code style followed
- Minimal diff size; no public API changes
- No plugin compatibility impact

---

**Patch files:**
- `patches/server/0124-PandaSpigot-Reuse-input-buffer-in-PacketCompressor-t.patch`
- `patches/server/0125-PandaSpigot-Replace-synchronized-packet-limiter-with.patch`
- `patches/server/0126-PandaSpigot-Reuse-PacketDataSerializer-instances-in-.patch`
- `patches/server/0127-PandaSpigot-Pool-QueuedPacket-objects-to-avoid-alloc.patch`
- `patches/server/0128-PandaSpigot-Login-optimizations-cache-brand-packet-d.patch`
