### PR TITLE
[WIP] Finish the unfinished player view distance API so its used everywhere

### DIFF
--- a/patches/server/0128-Remove-unfinished-player-view-distance-API.patch
+++ b/patches/server/0128-Remove-unfinished-player-view-distance-API.patch
@@ -1,0 +1,136 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: anzz1 <anzz1@live.com>
+Date: Thu, 18 Jun 2026 10:09:40 +0000
+Subject: [PATCH] Remove unfinished player view distance API
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
+index 6f804d5b1eaa085366b5213a98bc412cada1f078..79a88319c7c89dd02e053b9b363ff8e630f96bf7 100644
+--- a/src/main/java/net/minecraft/server/EntityPlayer.java
++++ b/src/main/java/net/minecraft/server/EntityPlayer.java
+@@ -65,7 +65,6 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+     // CraftBukkit end
+     // Spigot start
+     public boolean collidesWithEntities = true;
+-    public int viewDistance; // PaperSpigot - Player view distance API
+     private int containerUpdateDelay; // PaperSpigot
+ 
+     @Override
+@@ -83,7 +82,6 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+ 
+     public EntityPlayer(MinecraftServer minecraftserver, WorldServer worldserver, GameProfile gameprofile, PlayerInteractManager playerinteractmanager) {
+         super(worldserver, gameprofile);
+-        this.viewDistance = world.spigotConfig.viewDistance; // PaperSpigot - Player view distance API
+         playerinteractmanager.player = this;
+         this.playerInteractManager = playerinteractmanager;
+         BlockPosition blockposition = getSpawnPoint(minecraftserver, worldserver); // PandaSpigot - Split spawn point logic
+diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
+index 1c9dbe212cfbeb571f1e09f224fb7ed905dd475b..e1880604533f42c050b2bd0195f9f46c93409cc4 100644
+--- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
++++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
+@@ -129,10 +129,8 @@ public class PlayerChunkMap {
+         // CraftBukkit start - Load nearby chunks first
+         List<ChunkCoordIntPair> chunkList = new LinkedList<ChunkCoordIntPair>();
+ 
+-        // PaperSpigot start - Player view distance API
+-        for (int k = i - entityplayer.viewDistance; k <= i + entityplayer.viewDistance; ++k) {
+-            for (int l = j - entityplayer.viewDistance; l <= j + entityplayer.viewDistance; ++l) {
+-        // PaperSpigot end
++        for (int k = i - this.g; k <= i + this.g; ++k) {
++            for (int l = j - this.g; l <= j + this.g; ++l) {
+                 chunkList.add(new ChunkCoordIntPair(k, l));
+             }
+         }
+@@ -150,7 +148,7 @@ public class PlayerChunkMap {
+     public void b(EntityPlayer entityplayer) {
+         ArrayList arraylist = Lists.newArrayList(entityplayer.chunkCoordIntPairQueue);
+         int i = 0;
+-        int j = entityplayer.viewDistance; // PaperSpigot - Player view distance API
++        int j = this.g;
+         int k = (int) entityplayer.locX >> 4;
+         int l = (int) entityplayer.locZ >> 4;
+         int i1 = 0;
+@@ -196,10 +194,8 @@ public class PlayerChunkMap {
+         int i = (int) entityplayer.d >> 4;
+         int j = (int) entityplayer.e >> 4;
+ 
+-        // PaperSpigot start - Player view distance API
+-        for (int k = i - entityplayer.viewDistance; k <= i + entityplayer.viewDistance; ++k) {
+-            for (int l = j - entityplayer.viewDistance; l <= j + entityplayer.viewDistance; ++l) {
+-        // PaperSpigot end
++        for (int k = i - this.g; k <= i + this.g; ++k) {
++            for (int l = j - this.g; l <= j + this.g; ++l) {
+                 PlayerChunkMap.PlayerChunk playerchunkmap_playerchunk = this.a(k, l, false);
+ 
+                 if (playerchunkmap_playerchunk != null) {
+@@ -228,7 +224,7 @@ public class PlayerChunkMap {
+         if (d2 >= 64.0D) {
+             int k = (int) entityplayer.d >> 4;
+             int l = (int) entityplayer.e >> 4;
+-            int i1 = entityplayer.viewDistance; // PaperSpigot - Player view distance API
++            int i1 = this.g;
+             int j1 = i - k;
+             int k1 = j - l;
+             List<ChunkCoordIntPair> chunksToLoad = new LinkedList<ChunkCoordIntPair>(); // CraftBukkit
+@@ -313,38 +309,6 @@ public class PlayerChunkMap {
+         }
+     }
+ 
+-    // PaperSpigot start - Player view distance API
+-    public void updateViewDistance(EntityPlayer player, int viewDistance) {
+-        viewDistance = MathHelper.clamp(viewDistance, 3, 32);
+-        if (viewDistance != player.viewDistance) {
+-            int cx = (int) player.locX >> 4;
+-            int cz = (int) player.locZ >> 4;
+-
+-            if (viewDistance - player.viewDistance > 0) {
+-                for (int x = cx - viewDistance; x <= cx + viewDistance; ++x) {
+-                    for (int z = cz - viewDistance; z <= cz + viewDistance; ++z) {
+-                        PlayerChunkMap.PlayerChunk playerchunkmap_playerchunk = this.a(x, z, true);
+-
+-                        if (!playerchunkmap_playerchunk.b.contains(player)) {
+-                            playerchunkmap_playerchunk.a(player);
+-                        }
+-                    }
+-                }
+-            } else {
+-                for (int x = cx - player.viewDistance; x <= cx + player.viewDistance; ++x) {
+-                    for (int z = cz - player.viewDistance; z <= cz + player.viewDistance; ++z) {
+-                        if (!this.a(x, z, cx, cz, viewDistance)) {
+-                            this.a(x, z, true).b(player);
+-                        }
+-                    }
+-                }
+-            }
+-
+-            player.viewDistance = viewDistance;
+-        }
+-    }
+-    // PaperSpigot end
+-
+     public static int getFurthestViewableBlock(int i) {
+         return i * 16 - 16;
+     }
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 371906750db087081309f7263de5dfa0c3b61090..0b4eed24a941eb41c1641aa6aab671370505c019 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -1747,18 +1747,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         }
+         // PaperSpigot end
+ 
+-        // PaperSpigot start - Player view distance API
+-        @Override
+-        public int getViewDistance() {
+-            return getHandle().viewDistance;
+-        }
+-
+-        @Override
+-        public void setViewDistance(int viewDistance) {
+-            ((WorldServer) getHandle().world).getPlayerChunkMap().updateViewDistance(getHandle(), viewDistance);
+-        }
+-        // PaperSpigot end
+-
+         @Override
+         public int getPing()
+         {


### PR DESCRIPTION
This reverts the `0054-Add-player-view-distance-API.patch` from Spigot. The API was never finished and was later removed on newer Spigot as a system for per-player view distance would be unnecessarily complex and afaik the client doesn't transmit its preferred render distance anyway. Clean up the vestigial remains of this never-finished system.

The API side Player.getViewDistance() and Player.setViewDistance() which just throw UnsupportedOperationException anyway still stays to have 1:1 api compat with the original 1.8.8 spigot.
