### PR TITLE
Check randomLightUpdates

### DIFF
--- a/patches/server/0128-Alternative-Chunk-Ticking-Selection.patch
+++ b/patches/server/0128-Alternative-Chunk-Ticking-Selection.patch
@@ -61,7 +61,7 @@ index 652c07975c7b3a3c5e3dc68cb60ca5fc52e1848c..d93670b5fd2ee58a7b1d4ccd2479cc43
          return (this.x << 4) + 8;
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 1c9dbe212cfbeb571f1e09f224fb7ed905dd475b..4e5139ff054fdec1f1c603f720b37a74f572196d 100644
+index 1c9dbe212cfbeb571f1e09f224fb7ed905dd475b..6a489b4514d565b47d930a6ed1abf94cd863cf54 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -1,5 +1,9 @@
@@ -101,7 +101,7 @@ index 1c9dbe212cfbeb571f1e09f224fb7ed905dd475b..4e5139ff054fdec1f1c603f720b37a74
 +                        continue;
 +                    }
 +
-+                    if (!chunk.u() && chunk.isDone()) {
++                    if (PlayerChunkMap.this.world.spigotConfig.randomLightUpdates && !chunk.u() && chunk.isDone()) {
 +                        return chunk;
 +                    }
 +


### PR DESCRIPTION
When the chunk is populated, it sets:
done = true
lit = true
However, under certain conditions, `lit` might be set to `false` and attempt to update again on the next tick—though this only happens if `randomLightUpdates` is enabled.

In theory, the best approach here would be to keep `randomLightUpdates` enabled at all times (otherwise, theoretically, the lighting could never be populated correctly if it failed the first time).

However, I believe that would cause significant performance issues.

---

Did I mention I hate the chunk/lighting system in this version? 😂