### PR TITLE
Fix MC-233911 Wakeup Time Sync

### DIFF
--- a/patches/server/0015-Optimize-World-Time-Updates.patch
+++ b/patches/server/0015-Optimize-World-Time-Updates.patch
@@ -29,7 +29,7 @@ index 610775bfd092b988f907013f35bfc5b2adeb738a..dff0bb4bf07ce7b28f9115f5917e9a55
  
          int i;
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 87529552aa27fc89a542130a27a6b2bfdda44ccd..5b52fdb261f4cce3ad75619c1eff46be97458a75 100644
+index 87529552aa27fc89a542130a27a6b2bfdda44ccd..e1478127b9d1bc308a570ef3e137762f14a1225b 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -1215,6 +1215,25 @@ public class WorldServer extends World implements IAsyncTaskHandler {
@@ -49,7 +49,7 @@ index 87529552aa27fc89a542130a27a6b2bfdda44ccd..5b52fdb261f4cce3ad75619c1eff46be
 +            EntityPlayer entityplayer = (EntityPlayer) entityhuman;
 +            long playerTime = entityplayer.getPlayerTime();
 +            PacketPlayOutUpdateTime packet = (playerTime == dayTime) ? worldPacket :
-+                    new PacketPlayOutUpdateTime(worldTime, playerTime, doDaylight);
++                new PacketPlayOutUpdateTime(worldTime, playerTime, doDaylight);
 +            entityplayer.playerConnection.sendPacket(packet); // Add support for per player time
 +        }
 +    }

--- a/patches/server/0015-Optimize-World-Time-Updates.patch
+++ b/patches/server/0015-Optimize-World-Time-Updates.patch
@@ -8,10 +8,10 @@ the updates per world, so that we can re-use the same packet
 object for every player unless they have per-player time enabled.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 610775bfd092b988f907013f35bfc5b2adeb738a..735f8d4d08d9adf4daf31cb68045dda1d0229b94 100644
+index 610775bfd092b988f907013f35bfc5b2adeb738a..dff0bb4bf07ce7b28f9115f5917e9a55bf36bec0 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -796,12 +796,24 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+@@ -796,12 +796,11 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
  
          SpigotTimings.timeUpdateTimer.startTiming(); // Spigot
          // Send time updates to everyone, it will get the right time from the world the player is in.
@@ -19,24 +19,42 @@ index 610775bfd092b988f907013f35bfc5b2adeb738a..735f8d4d08d9adf4daf31cb68045dda1
 -            for (int i = 0; i < this.getPlayerList().players.size(); ++i) {
 -                EntityPlayer entityplayer = (EntityPlayer) this.getPlayerList().players.get(i);
 -                entityplayer.playerConnection.sendPacket(new PacketPlayOutUpdateTime(entityplayer.world.getTime(), entityplayer.getPlayerTime(), entityplayer.world.getGameRules().getBoolean("doDaylightCycle"))); // Add support for per player time
-+        // PandaSpigot start - optimize time updates
+-            }
++        // PandaSpigot start - Optimize World Time Updates
 +        for (final WorldServer world : this.worlds) {
-+            final boolean doDaylight = world.getGameRules().getBoolean("doDaylightCycle");
-+            final long dayTime = world.getDayTime();
-+            long worldTime = world.getTime();
-+            final PacketPlayOutUpdateTime worldPacket = new PacketPlayOutUpdateTime(worldTime, dayTime, doDaylight);
-+            for (EntityHuman entityhuman : world.players) {
-+                if (!(entityhuman instanceof EntityPlayer) || (this.ticks + entityhuman.getId()) % 20 != 0) {
-+                    continue;
-+                }
-+                EntityPlayer entityplayer = (EntityPlayer) entityhuman;
-+                long playerTime = entityplayer.getPlayerTime();
-+                PacketPlayOutUpdateTime packet = (playerTime == dayTime) ? worldPacket :
-+                        new PacketPlayOutUpdateTime(worldTime, playerTime, doDaylight);
-+                entityplayer.playerConnection.sendPacket(packet); // Add support for per player time
-             }
++            world.sendWorldTimeUpdate(false);
          }
 +        // PandaSpigot end
          SpigotTimings.timeUpdateTimer.stopTiming(); // Spigot
  
          int i;
+diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
+index 87529552aa27fc89a542130a27a6b2bfdda44ccd..5b52fdb261f4cce3ad75619c1eff46be97458a75 100644
+--- a/src/main/java/net/minecraft/server/WorldServer.java
++++ b/src/main/java/net/minecraft/server/WorldServer.java
+@@ -1215,6 +1215,25 @@ public class WorldServer extends World implements IAsyncTaskHandler {
+ 
+     }
+ 
++    // PandaSpigot start - Optimize World Time Updates
++    public void sendWorldTimeUpdate(boolean force) {
++        final boolean doDaylight = this.getGameRules().getBoolean("doDaylightCycle");
++        final long dayTime = this.getDayTime();
++        long worldTime = this.getTime();
++        final PacketPlayOutUpdateTime worldPacket = new PacketPlayOutUpdateTime(worldTime, dayTime, doDaylight);
++        for (EntityHuman entityhuman : this.players) {
++            if (!(entityhuman instanceof EntityPlayer) || (!force && (this.server.at() + entityhuman.getId()) % 20 != 0)) {
++                continue;
++            }
++            EntityPlayer entityplayer = (EntityPlayer) entityhuman;
++            long playerTime = entityplayer.getPlayerTime();
++            PacketPlayOutUpdateTime packet = (playerTime == dayTime) ? worldPacket :
++                    new PacketPlayOutUpdateTime(worldTime, playerTime, doDaylight);
++            entityplayer.playerConnection.sendPacket(packet); // Add support for per player time
++        }
++    }
++    // PandaSpigot end
++
+     public Entity getEntity(UUID uuid) {
+         return (Entity) this.entitiesByUUID.get(uuid);
+     }

--- a/patches/server/0016-Configurable-time-update-frequency.patch
+++ b/patches/server/0016-Configurable-time-update-frequency.patch
@@ -1,11 +1,11 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: hpfxd <me@hpfxd.com>
 Date: Sat, 30 Oct 2021 14:42:18 -0400
-Subject: [PATCH] Configurable time update frequency.
+Subject: [PATCH] Configurable time update frequency
 
 
 diff --git a/src/main/java/com/hpfxd/pandaspigot/config/PandaSpigotWorldConfig.java b/src/main/java/com/hpfxd/pandaspigot/config/PandaSpigotWorldConfig.java
-index 3dd3d0702c17541083d0d365ca46e93602105bce..b5f16e8cab9e43ad7597b2ea5bc921399b37872b 100644
+index 3dd3d0702c17541083d0d365ca46e93602105bce..ff05881b80710d989a619baf21e07ad16eafb61d 100644
 --- a/src/main/java/com/hpfxd/pandaspigot/config/PandaSpigotWorldConfig.java
 +++ b/src/main/java/com/hpfxd/pandaspigot/config/PandaSpigotWorldConfig.java
 @@ -6,6 +6,12 @@ import org.spongepowered.configurate.objectmapping.meta.Comment;
@@ -21,16 +21,16 @@ index 3dd3d0702c17541083d0d365ca46e93602105bce..b5f16e8cab9e43ad7597b2ea5bc92139
      @Comment("These options control velocity players receive when damaged.")
      public KnockbackConfig knockback;
      
-diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 735f8d4d08d9adf4daf31cb68045dda1d0229b94..918863f601bb2199f5b46ca85f54152c138bbe7e 100644
---- a/src/main/java/net/minecraft/server/MinecraftServer.java
-+++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -803,7 +803,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
-             long worldTime = world.getTime();
-             final PacketPlayOutUpdateTime worldPacket = new PacketPlayOutUpdateTime(worldTime, dayTime, doDaylight);
-             for (EntityHuman entityhuman : world.players) {
--                if (!(entityhuman instanceof EntityPlayer) || (this.ticks + entityhuman.getId()) % 20 != 0) {
-+                if (!(entityhuman instanceof EntityPlayer) || (this.ticks + entityhuman.getId()) % world.pandaSpigotConfig.timeUpdateFrequency != 0) {
-                     continue;
-                 }
-                 EntityPlayer entityplayer = (EntityPlayer) entityhuman;
+diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
+index 5b52fdb261f4cce3ad75619c1eff46be97458a75..795deaa6470a30d4602e6a1494b2575cf5202844 100644
+--- a/src/main/java/net/minecraft/server/WorldServer.java
++++ b/src/main/java/net/minecraft/server/WorldServer.java
+@@ -1222,7 +1222,7 @@ public class WorldServer extends World implements IAsyncTaskHandler {
+         long worldTime = this.getTime();
+         final PacketPlayOutUpdateTime worldPacket = new PacketPlayOutUpdateTime(worldTime, dayTime, doDaylight);
+         for (EntityHuman entityhuman : this.players) {
+-            if (!(entityhuman instanceof EntityPlayer) || (!force && (this.server.at() + entityhuman.getId()) % 20 != 0)) {
++            if (!(entityhuman instanceof EntityPlayer) || (!force && (this.server.at() + entityhuman.getId()) % this.pandaSpigotConfig.timeUpdateFrequency != 0)) { // PandaSpigot - Configurable time update frequency
+                 continue;
+             }
+             EntityPlayer entityplayer = (EntityPlayer) entityhuman;

--- a/patches/server/0016-Configurable-time-update-frequency.patch
+++ b/patches/server/0016-Configurable-time-update-frequency.patch
@@ -22,7 +22,7 @@ index 3dd3d0702c17541083d0d365ca46e93602105bce..ff05881b80710d989a619baf21e07ad1
      public KnockbackConfig knockback;
      
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 5b52fdb261f4cce3ad75619c1eff46be97458a75..795deaa6470a30d4602e6a1494b2575cf5202844 100644
+index e1478127b9d1bc308a570ef3e137762f14a1225b..795deaa6470a30d4602e6a1494b2575cf5202844 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -1222,7 +1222,7 @@ public class WorldServer extends World implements IAsyncTaskHandler {

--- a/patches/server/0021-EntityMoveEvent.patch
+++ b/patches/server/0021-EntityMoveEvent.patch
@@ -31,10 +31,10 @@ index 72c7e6fc8bb0a71877d6759af44d39030bcf51f5..1353a791235ae3b820072fa80ef60c3c
  
      protected void doTick() {}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 918863f601bb2199f5b46ca85f54152c138bbe7e..00429aa61ca5dbfc8ebc29557d20b5b40e4ea6b3 100644
+index dff0bb4bf07ce7b28f9115f5917e9a55bf36bec0..0113ae0f14e2d49818011e496c4c7a6c9c25a19e 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -823,6 +823,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+@@ -810,6 +810,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
  
              // if (i == 0 || this.getAllowNether()) {
                  WorldServer worldserver = this.worlds.get(i);
@@ -43,7 +43,7 @@ index 918863f601bb2199f5b46ca85f54152c138bbe7e..00429aa61ca5dbfc8ebc29557d20b5b4
                  this.methodProfiler.a(worldserver.getWorldData().getName());
                  /* Drop global time updates
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index f54a279407ad09fabcac038b11e8d668e68c35f6..9bf5b0a7d4b7eac5496768b3ce8dad22b02b332c 100644
+index 179d2e3625e3e538170eeae88bf7c70630767d06..2320da544fd0faa727ba9ba8569e33fc57c6bd00 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -49,6 +49,7 @@ public class WorldServer extends World implements IAsyncTaskHandler {

--- a/patches/server/0033-Backport-PlayerProfile-API.patch
+++ b/patches/server/0033-Backport-PlayerProfile-API.patch
@@ -320,10 +320,10 @@ index 04916c6a8ee6446e786eb23c54ae78e8d2cba84d..8388bb5bae0c3b072b191b9d3655873f
      public EntityFishingHook hookedFish;
      public boolean affectsSpawning = true; // PaperSpigot
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index bed9076fc52dc7a4f2ee3fe28c2a3f72fb6b0293..e9550824b63f7c6fc211ecee2e5ec0a9131f57ad 100644
+index 95eb15f15f1414d35640a19cbd591e6947696ac0..00c51011ad0dc953064c2c635550fe92025b6bdd 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1536,6 +1536,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+@@ -1523,6 +1523,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
          return true;
      }
  

--- a/patches/server/0037-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0037-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -251,7 +251,7 @@ index 97699e7f86cef3ab8c4560066f0ef93c18a8f5ad..9bcfa3d9f26f88e704903d90695ab88b
          System.setOut(new PrintStream(new LoggerOutputStream(logger, Level.INFO), true));
          System.setErr(new PrintStream(new LoggerOutputStream(logger, Level.WARN), true));
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index e9550824b63f7c6fc211ecee2e5ec0a9131f57ad..82c7de05cb6af9e179da419eed0545c16592320b 100644
+index 00c51011ad0dc953064c2c635550fe92025b6bdd..d071805238fc401abdee89398f91516ab16ef4ff 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -41,7 +41,7 @@ import org.apache.logging.log4j.Logger;
@@ -300,7 +300,7 @@ index e9550824b63f7c6fc211ecee2e5ec0a9131f57ad..82c7de05cb6af9e179da419eed0545c1
                  } catch (Exception ignored) {
                  }
                  // CraftBukkit end
-@@ -1204,7 +1209,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+@@ -1191,7 +1196,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
      }
  
      public void sendMessage(IChatBaseComponent ichatbasecomponent) {

--- a/patches/server/0044-Only-process-BlockPhysicsEvent-if-a-plugin-has-a-lis.patch
+++ b/patches/server/0044-Only-process-BlockPhysicsEvent-if-a-plugin-has-a-lis.patch
@@ -26,10 +26,10 @@ index c1110242136e8fd98661886920b765bb5367c37d..558ab56e5f2e670dc17e8ffd39d8f09d
              this.b(world, blockposition, iblockdata, 0);
              world.setTypeAndData(blockposition, Blocks.AIR.getBlockData(), 3);
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 82c7de05cb6af9e179da419eed0545c16592320b..919871cc851bba4067c0e6627c7b70faa1c96782 100644
+index d071805238fc401abdee89398f91516ab16ef4ff..0ed943bb6a6da43a71eddb7aac8e9a5294aecce5 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -831,6 +831,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+@@ -818,6 +818,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
              // if (i == 0 || this.getAllowNether()) {
                  WorldServer worldserver = this.worlds.get(i);
                  worldserver.hasEntityMoveEvent = io.papermc.paper.event.entity.EntityMoveEvent.getHandlerList().getRegisteredListeners().length > 0; // PandaSpigot
@@ -51,7 +51,7 @@ index 42c077870727d1eb40bc9bf5e0a3ca580131331d..589bf95c13e9c78c792498a7b73fd048
                      this.getServer().getPluginManager().callEvent(event);
  
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 9bf5b0a7d4b7eac5496768b3ce8dad22b02b332c..0700b5aec26a6a4ba4db4d3c66b8b15c295c5a03 100644
+index 2320da544fd0faa727ba9ba8569e33fc57c6bd00..eee932b24cdd3cb07f318586f4c5fb27de37b42c 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -50,6 +50,7 @@ public class WorldServer extends World implements IAsyncTaskHandler {

--- a/patches/server/0066-Skip-updating-entity-tracker-if-server-is-empty.patch
+++ b/patches/server/0066-Skip-updating-entity-tracker-if-server-is-empty.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Skip updating entity tracker if server is empty
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 919871cc851bba4067c0e6627c7b70faa1c96782..ef17d45eb60ea375aad19ccc31773fa3c2346841 100644
+index 0ed943bb6a6da43a71eddb7aac8e9a5294aecce5..b50930ad4e28c45ad76a3f475ea1eebe15c96ec0 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -893,7 +893,9 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+@@ -880,7 +880,9 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
                  }
                  try {
                  // PandaSpigot end

--- a/patches/server/0133-Fix-MC-233911-Wakeup-Time-Sync.patch
+++ b/patches/server/0133-Fix-MC-233911-Wakeup-Time-Sync.patch
@@ -1,39 +1,48 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: anzz1 <anzz1@live.com>
-Date: Sun, 28 Jun 2026 17:18:47 +0000
+Date: Mon, 27 Jul 2026 08:03:39 +0000
 Subject: [PATCH] Fix MC-233911 Wakeup Time Sync
 
-Sends a time sync packet immediately after waking up.
-This should make players wake up to daylight as long as they aren't
-lagging too much.
+Sends a time sync packet immediately after waking up from sleep.
 
+diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
+index ae0259e025d1121adb5d09cda05e84fe711d8a35..d5993c69ffcfba7334d4a614b056b665978e6622 100644
+--- a/src/main/java/net/minecraft/server/MinecraftServer.java
++++ b/src/main/java/net/minecraft/server/MinecraftServer.java
+@@ -857,7 +857,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+             long worldTime = world.getTime();
+             final PacketPlayOutUpdateTime worldPacket = new PacketPlayOutUpdateTime(worldTime, dayTime, doDaylight);
+             for (EntityHuman entityhuman : world.players) {
+-                if (!(entityhuman instanceof EntityPlayer) || (this.ticks + entityhuman.getId()) % world.pandaSpigotConfig.timeUpdateFrequency != 0) {
++                if (!(entityhuman instanceof EntityPlayer) || (!world.timeNeedsSync && (this.ticks + entityhuman.getId()) % world.pandaSpigotConfig.timeUpdateFrequency != 0)) { // PandaSpigot - Wakeup Time Sync
+                     continue;
+                 }
+                 EntityPlayer entityplayer = (EntityPlayer) entityhuman;
+@@ -866,6 +866,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+                         new PacketPlayOutUpdateTime(worldTime, playerTime, doDaylight);
+                 entityplayer.playerConnection.sendPacket(packet); // Add support for per player time
+             }
++            world.timeNeedsSync = false; // PandaSpigot - Wakeup Time Sync
+         }
+         // PandaSpigot end
+         SpigotTimings.timeUpdateTimer.stopTiming(); // Spigot
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 1c9e429b4107daf0991fe0c61bd5377cf4c22c95..3469119b6bc502bbf6db005189381a4cc1e5a248 100644
+index 1c9e429b4107daf0991fe0c61bd5377cf4c22c95..28f7e597c7a1088b9bd6b9878ef8d62ef842a403 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
-@@ -212,11 +212,13 @@ public class WorldServer extends World implements IAsyncTaskHandler {
-         }
+@@ -51,6 +51,7 @@ public class WorldServer extends World implements IAsyncTaskHandler {
+     private List<NextTickListEntry> V = Lists.newArrayList();
+     public boolean hasEntityMoveEvent = false; // PandaSpigot
+     public boolean hasPhysicsEvent = true; // PandaSpigot
++    public boolean timeNeedsSync = false; // PandaSpigot - Wakeup Time Sync
  
-         this.worldProvider.m().b();
-+        boolean timeNeedsSync = false; // PandaSpigot - Wakeup Time Sync
-         if (this.everyoneDeeplySleeping()) {
-             if (this.getGameRules().getBoolean("doDaylightCycle")) {
+     // CraftBukkit start
+     public final int dimension;
+@@ -217,6 +218,7 @@ public class WorldServer extends World implements IAsyncTaskHandler {
                  long i = this.worldData.getDayTime() + 24000L;
  
                  this.worldData.setDayTime(i - i % 24000L);
-+                timeNeedsSync = true;  // PandaSpigot - Wakeup Time Sync
++                this.timeNeedsSync = true;  // PandaSpigot - Wakeup Time Sync
              }
  
              this.e();
-@@ -243,6 +245,11 @@ public class WorldServer extends World implements IAsyncTaskHandler {
-         this.worldData.setTime(this.worldData.getTime() + 1L);
-         if (this.getGameRules().getBoolean("doDaylightCycle")) {
-             this.worldData.setDayTime(this.worldData.getDayTime() + 1L);
-+            // PandaSpigot start - Wakeup Time Sync
-+            if (timeNeedsSync) {
-+                this.server.getPlayerList().a(new PacketPlayOutUpdateTime(this.worldData.getTime(), this.worldData.getDayTime(), true), this.worldProvider.getDimension());
-+            }
-+            // PandaSpigot end
-         }
- 
-         timings.doChunkUnload.stopTiming(); // Spigot

--- a/patches/server/0133-Fix-MC-233911-Wakeup-Time-Sync.patch
+++ b/patches/server/0133-Fix-MC-233911-Wakeup-Time-Sync.patch
@@ -1,38 +1,12 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: anzz1 <anzz1@live.com>
-Date: Wed, 29 Jul 2026 11:48:50 +0000
+Date: Wed, 29 Jul 2026 15:40:47 +0000
 Subject: [PATCH] Fix MC-233911 Wakeup Time Sync
 
 Sends a time sync packet immediately after waking up from sleep.
 
-diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index ae0259e025d1121adb5d09cda05e84fe711d8a35..d5787e5cbe3771cb737aca26a18056a8e552bf16 100644
---- a/src/main/java/net/minecraft/server/MinecraftServer.java
-+++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -852,20 +852,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
-         // Send time updates to everyone, it will get the right time from the world the player is in.
-         // PandaSpigot start - optimize time updates
-         for (final WorldServer world : this.worlds) {
--            final boolean doDaylight = world.getGameRules().getBoolean("doDaylightCycle");
--            final long dayTime = world.getDayTime();
--            long worldTime = world.getTime();
--            final PacketPlayOutUpdateTime worldPacket = new PacketPlayOutUpdateTime(worldTime, dayTime, doDaylight);
--            for (EntityHuman entityhuman : world.players) {
--                if (!(entityhuman instanceof EntityPlayer) || (this.ticks + entityhuman.getId()) % world.pandaSpigotConfig.timeUpdateFrequency != 0) {
--                    continue;
--                }
--                EntityPlayer entityplayer = (EntityPlayer) entityhuman;
--                long playerTime = entityplayer.getPlayerTime();
--                PacketPlayOutUpdateTime packet = (playerTime == dayTime) ? worldPacket :
--                        new PacketPlayOutUpdateTime(worldTime, playerTime, doDaylight);
--                entityplayer.playerConnection.sendPacket(packet); // Add support for per player time
--            }
-+            world.sendTimeUpdate(false);
-         }
-         // PandaSpigot end
-         SpigotTimings.timeUpdateTimer.stopTiming(); // Spigot
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 1c9e429b4107daf0991fe0c61bd5377cf4c22c95..c72867cbf8300eb50692ed53c2f5a15b5387ca9e 100644
+index a1f85f055d4e8418cb9733832cd36037cafc1793..caa0b174932468a616d283e79ccc3995d54877dd 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -212,11 +212,13 @@ public class WorldServer extends World implements IAsyncTaskHandler {
@@ -54,34 +28,8 @@ index 1c9e429b4107daf0991fe0c61bd5377cf4c22c95..c72867cbf8300eb50692ed53c2f5a15b
          if (this.getGameRules().getBoolean("doDaylightCycle")) {
              this.worldData.setDayTime(this.worldData.getDayTime() + 1L);
 +            if (timeNeedsSync) {
-+                this.sendTimeUpdate(true); // PandaSpigot - Wakeup Time Sync
++                this.sendWorldTimeUpdate(true); // PandaSpigot - Wakeup Time Sync
 +            }
          }
  
          timings.doChunkUnload.stopTiming(); // Spigot
-@@ -1384,6 +1389,25 @@ public class WorldServer extends World implements IAsyncTaskHandler {
- 
-     }
- 
-+    // PandaSpigot start
-+    public void sendTimeUpdate(boolean force) {
-+        final boolean doDaylight = this.getGameRules().getBoolean("doDaylightCycle");
-+        final long dayTime = this.getDayTime();
-+        long worldTime = this.getTime();
-+        final PacketPlayOutUpdateTime worldPacket = new PacketPlayOutUpdateTime(worldTime, dayTime, doDaylight);
-+        for (EntityHuman entityhuman : this.players) {
-+            if (!(entityhuman instanceof EntityPlayer) || (!force && (this.server.at() + entityhuman.getId()) % this.pandaSpigotConfig.timeUpdateFrequency != 0)) {
-+                continue;
-+            }
-+            EntityPlayer entityplayer = (EntityPlayer) entityhuman;
-+            long playerTime = entityplayer.getPlayerTime();
-+            PacketPlayOutUpdateTime packet = (playerTime == dayTime) ? worldPacket :
-+                    new PacketPlayOutUpdateTime(worldTime, playerTime, doDaylight);
-+            entityplayer.playerConnection.sendPacket(packet); // Add support for per player time
-+        }
-+    }
-+    // PandaSpigot end
-+
-     public Entity getEntity(UUID uuid) {
-         return (Entity) this.entitiesByUUID.get(uuid);
-     }

--- a/patches/server/0133-Fix-MC-233911-Wakeup-Time-Sync.patch
+++ b/patches/server/0133-Fix-MC-233911-Wakeup-Time-Sync.patch
@@ -1,123 +1,65 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: anzz1 <anzz1@live.com>
-Date: Mon, 27 Jul 2026 08:03:39 +0000
+Date: Wed, 29 Jul 2026 11:48:50 +0000
 Subject: [PATCH] Fix MC-233911 Wakeup Time Sync
 
 Sends a time sync packet immediately after waking up from sleep.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index ae0259e025d1121adb5d09cda05e84fe711d8a35..95526f4116124d60d5f0e630d0b4642737f6f0fb 100644
+index ae0259e025d1121adb5d09cda05e84fe711d8a35..d5787e5cbe3771cb737aca26a18056a8e552bf16 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -857,7 +857,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
-             long worldTime = world.getTime();
-             final PacketPlayOutUpdateTime worldPacket = new PacketPlayOutUpdateTime(worldTime, dayTime, doDaylight);
-             for (EntityHuman entityhuman : world.players) {
+@@ -852,20 +852,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+         // Send time updates to everyone, it will get the right time from the world the player is in.
+         // PandaSpigot start - optimize time updates
+         for (final WorldServer world : this.worlds) {
+-            final boolean doDaylight = world.getGameRules().getBoolean("doDaylightCycle");
+-            final long dayTime = world.getDayTime();
+-            long worldTime = world.getTime();
+-            final PacketPlayOutUpdateTime worldPacket = new PacketPlayOutUpdateTime(worldTime, dayTime, doDaylight);
+-            for (EntityHuman entityhuman : world.players) {
 -                if (!(entityhuman instanceof EntityPlayer) || (this.ticks + entityhuman.getId()) % world.pandaSpigotConfig.timeUpdateFrequency != 0) {
-+                if (!(entityhuman instanceof EntityPlayer) || (!world.timeNeedsSync && (this.ticks + entityhuman.getId()) % world.pandaSpigotConfig.timeUpdateFrequency != 0)) { // PandaSpigot - Wakeup Time Sync
-                     continue;
-                 }
-                 EntityPlayer entityplayer = (EntityPlayer) entityhuman;
-@@ -866,6 +866,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
-                         new PacketPlayOutUpdateTime(worldTime, playerTime, doDaylight);
-                 entityplayer.playerConnection.sendPacket(packet); // Add support for per player time
-             }
-+            world.timeNeedsSync = false; // PandaSpigot - Wakeup Time Sync
+-                    continue;
+-                }
+-                EntityPlayer entityplayer = (EntityPlayer) entityhuman;
+-                long playerTime = entityplayer.getPlayerTime();
+-                PacketPlayOutUpdateTime packet = (playerTime == dayTime) ? worldPacket :
+-                        new PacketPlayOutUpdateTime(worldTime, playerTime, doDaylight);
+-                entityplayer.playerConnection.sendPacket(packet); // Add support for per player time
+-            }
++            world.sendTimeUpdate(false);
          }
          // PandaSpigot end
          SpigotTimings.timeUpdateTimer.stopTiming(); // Spigot
-@@ -1518,61 +1519,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
-     }
-     // Spigot End
-     public ServerConnection aq() {
--        return this.q == null ? this.q = new ServerConnection(this) : this.q; // Spigot
--    }
--
--    public boolean as() {
--        return false;
--    }
--
--    public abstract String a(WorldSettings.EnumGamemode worldsettings_enumgamemode, boolean flag);
--
--    public int at() {
--        return this.ticks;
--    }
--
--    public void au() {
--        this.T = true;
--    }
--
--    public BlockPosition getChunkCoordinates() {
--        return BlockPosition.ZERO;
--    }
--
--    public Vec3D d() {
--        return new Vec3D(0.0D, 0.0D, 0.0D);
--    }
--
--    public World getWorld() {
--        return this.worlds.get(0); // CraftBukkit
--    }
--
--    public Entity f() {
--        return null;
--    }
--
--    public int getSpawnProtection() {
--        return 16;
--    }
--
--    public boolean a(World world, BlockPosition blockposition, EntityHuman entityhuman) {
--        return false;
--    }
--
--    public void setForceGamemode(boolean flag) {
--        this.U = flag;
--    }
--
--    public boolean getForceGamemode() {
--        return this.U;
--    }
--
--    public Proxy ay() {
--        return this.e;
--    }
--
--    public static long az() {
--        return System.currentTimeMillis();
-+        return this.qimeMillis();
-     }
- 
-     public int getIdleTimeout() {
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 1c9e429b4107daf0991fe0c61bd5377cf4c22c95..c067d4e819dd6617adeb68d4cd2344e1eed1b4af 100644
+index 1c9e429b4107daf0991fe0c61bd5377cf4c22c95..c72867cbf8300eb50692ed53c2f5a15b5387ca9e 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
-@@ -51,6 +51,7 @@ public class WorldServer extends World implements IAsyncTaskHandler {
-     private List<NextTickListEntry> V = Lists.newArrayList();
-     public boolean hasEntityMoveEvent = false; // PandaSpigot
-     public boolean hasPhysicsEvent = true; // PandaSpigot
-+    public boolean timeNeedsSync = false; // PandaSpigot - Wakeup Time Sync
+@@ -212,11 +212,13 @@ public class WorldServer extends World implements IAsyncTaskHandler {
+         }
  
-     // CraftBukkit start
-     public final int dimension;
-@@ -217,6 +218,7 @@ public class WorldServer extends World implements IAsyncTaskHandler {
+         this.worldProvider.m().b();
++        boolean timeNeedsSync = false; // PandaSpigot - Wakeup Time Sync
+         if (this.everyoneDeeplySleeping()) {
+             if (this.getGameRules().getBoolean("doDaylightCycle")) {
                  long i = this.worldData.getDayTime() + 24000L;
  
                  this.worldData.setDayTime(i - i % 24000L);
-+                this.timeNeedsSync = true;  // PandaSpigot - Wakeup Time Sync
++                timeNeedsSync = true; // PandaSpigot - Wakeup Time Sync
              }
  
              this.e();
-@@ -1373,6 +1375,7 @@ public class WorldServer extends World implements IAsyncTaskHandler {
+@@ -243,6 +245,9 @@ public class WorldServer extends World implements IAsyncTaskHandler {
+         this.worldData.setTime(this.worldData.getTime() + 1L);
+         if (this.getGameRules().getBoolean("doDaylightCycle")) {
+             this.worldData.setDayTime(this.worldData.getDayTime() + 1L);
++            if (timeNeedsSync) {
++                this.sendTimeUpdate(true); // PandaSpigot - Wakeup Time Sync
++            }
+         }
  
-         for (int j = 0; j < this.players.size(); ++j) {
-             EntityPlayer entityplayer = (EntityPlayer) this.players.get(j);
-+            if (sender != null && !entityplayer.getBukkitEntity().canSee(sender.getBukkitEntity())) continue;t(j);
-             if (sender != null && !entityplayer.getBukkitEntity().canSee(sender.getBukkitEntity())) continue; // CraftBukkit
-             BlockPosition blockposition = entityplayer.getChunkCoordinates();
-             double d7 = blockposition.c(d0, d1, d2);
-@@ -1384,6 +1387,25 @@ public class WorldServer extends World implements IAsyncTaskHandler {
+         timings.doChunkUnload.stopTiming(); // Spigot
+@@ -1384,6 +1389,25 @@ public class WorldServer extends World implements IAsyncTaskHandler {
  
      }
  

--- a/patches/server/0133-Fix-MC-233911-Wakeup-Time-Sync.patch
+++ b/patches/server/0133-Fix-MC-233911-Wakeup-Time-Sync.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: anzz1 <anzz1@live.com>
+Date: Sun, 28 Jun 2026 17:18:47 +0000
+Subject: [PATCH] Fix MC-233911 Wakeup Time Sync
+
+Sends a time sync packet immediately after waking up.
+This should make players wake up to daylight as long as they aren't
+lagging too much.
+
+diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
+index 1c9e429b4107daf0991fe0c61bd5377cf4c22c95..3469119b6bc502bbf6db005189381a4cc1e5a248 100644
+--- a/src/main/java/net/minecraft/server/WorldServer.java
++++ b/src/main/java/net/minecraft/server/WorldServer.java
+@@ -212,11 +212,13 @@ public class WorldServer extends World implements IAsyncTaskHandler {
+         }
+ 
+         this.worldProvider.m().b();
++        boolean timeNeedsSync = false; // PandaSpigot - Wakeup Time Sync
+         if (this.everyoneDeeplySleeping()) {
+             if (this.getGameRules().getBoolean("doDaylightCycle")) {
+                 long i = this.worldData.getDayTime() + 24000L;
+ 
+                 this.worldData.setDayTime(i - i % 24000L);
++                timeNeedsSync = true;  // PandaSpigot - Wakeup Time Sync
+             }
+ 
+             this.e();
+@@ -243,6 +245,11 @@ public class WorldServer extends World implements IAsyncTaskHandler {
+         this.worldData.setTime(this.worldData.getTime() + 1L);
+         if (this.getGameRules().getBoolean("doDaylightCycle")) {
+             this.worldData.setDayTime(this.worldData.getDayTime() + 1L);
++            // PandaSpigot start - Wakeup Time Sync
++            if (timeNeedsSync) {
++                this.server.getPlayerList().a(new PacketPlayOutUpdateTime(this.worldData.getTime(), this.worldData.getDayTime(), true), this.worldProvider.getDimension());
++            }
++            // PandaSpigot end
+         }
+ 
+         timings.doChunkUnload.stopTiming(); // Spigot

--- a/patches/server/0133-Fix-MC-233911-Wakeup-Time-Sync.patch
+++ b/patches/server/0133-Fix-MC-233911-Wakeup-Time-Sync.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Fix MC-233911 Wakeup Time Sync
 Sends a time sync packet immediately after waking up from sleep.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index ae0259e025d1121adb5d09cda05e84fe711d8a35..d5993c69ffcfba7334d4a614b056b665978e6622 100644
+index ae0259e025d1121adb5d09cda05e84fe711d8a35..95526f4116124d60d5f0e630d0b4642737f6f0fb 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -857,7 +857,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
@@ -26,8 +26,71 @@ index ae0259e025d1121adb5d09cda05e84fe711d8a35..d5993c69ffcfba7334d4a614b056b665
          }
          // PandaSpigot end
          SpigotTimings.timeUpdateTimer.stopTiming(); // Spigot
+@@ -1518,61 +1519,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+     }
+     // Spigot End
+     public ServerConnection aq() {
+-        return this.q == null ? this.q = new ServerConnection(this) : this.q; // Spigot
+-    }
+-
+-    public boolean as() {
+-        return false;
+-    }
+-
+-    public abstract String a(WorldSettings.EnumGamemode worldsettings_enumgamemode, boolean flag);
+-
+-    public int at() {
+-        return this.ticks;
+-    }
+-
+-    public void au() {
+-        this.T = true;
+-    }
+-
+-    public BlockPosition getChunkCoordinates() {
+-        return BlockPosition.ZERO;
+-    }
+-
+-    public Vec3D d() {
+-        return new Vec3D(0.0D, 0.0D, 0.0D);
+-    }
+-
+-    public World getWorld() {
+-        return this.worlds.get(0); // CraftBukkit
+-    }
+-
+-    public Entity f() {
+-        return null;
+-    }
+-
+-    public int getSpawnProtection() {
+-        return 16;
+-    }
+-
+-    public boolean a(World world, BlockPosition blockposition, EntityHuman entityhuman) {
+-        return false;
+-    }
+-
+-    public void setForceGamemode(boolean flag) {
+-        this.U = flag;
+-    }
+-
+-    public boolean getForceGamemode() {
+-        return this.U;
+-    }
+-
+-    public Proxy ay() {
+-        return this.e;
+-    }
+-
+-    public static long az() {
+-        return System.currentTimeMillis();
++        return this.qimeMillis();
+     }
+ 
+     public int getIdleTimeout() {
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 1c9e429b4107daf0991fe0c61bd5377cf4c22c95..28f7e597c7a1088b9bd6b9878ef8d62ef842a403 100644
+index 1c9e429b4107daf0991fe0c61bd5377cf4c22c95..c067d4e819dd6617adeb68d4cd2344e1eed1b4af 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -51,6 +51,7 @@ public class WorldServer extends World implements IAsyncTaskHandler {
@@ -46,3 +109,37 @@ index 1c9e429b4107daf0991fe0c61bd5377cf4c22c95..28f7e597c7a1088b9bd6b9878ef8d62e
              }
  
              this.e();
+@@ -1373,6 +1375,7 @@ public class WorldServer extends World implements IAsyncTaskHandler {
+ 
+         for (int j = 0; j < this.players.size(); ++j) {
+             EntityPlayer entityplayer = (EntityPlayer) this.players.get(j);
++            if (sender != null && !entityplayer.getBukkitEntity().canSee(sender.getBukkitEntity())) continue;t(j);
+             if (sender != null && !entityplayer.getBukkitEntity().canSee(sender.getBukkitEntity())) continue; // CraftBukkit
+             BlockPosition blockposition = entityplayer.getChunkCoordinates();
+             double d7 = blockposition.c(d0, d1, d2);
+@@ -1384,6 +1387,25 @@ public class WorldServer extends World implements IAsyncTaskHandler {
+ 
+     }
+ 
++    // PandaSpigot start
++    public void sendTimeUpdate(boolean force) {
++        final boolean doDaylight = this.getGameRules().getBoolean("doDaylightCycle");
++        final long dayTime = this.getDayTime();
++        long worldTime = this.getTime();
++        final PacketPlayOutUpdateTime worldPacket = new PacketPlayOutUpdateTime(worldTime, dayTime, doDaylight);
++        for (EntityHuman entityhuman : this.players) {
++            if (!(entityhuman instanceof EntityPlayer) || (!force && (this.server.at() + entityhuman.getId()) % this.pandaSpigotConfig.timeUpdateFrequency != 0)) {
++                continue;
++            }
++            EntityPlayer entityplayer = (EntityPlayer) entityhuman;
++            long playerTime = entityplayer.getPlayerTime();
++            PacketPlayOutUpdateTime packet = (playerTime == dayTime) ? worldPacket :
++                    new PacketPlayOutUpdateTime(worldTime, playerTime, doDaylight);
++            entityplayer.playerConnection.sendPacket(packet); // Add support for per player time
++        }
++    }
++    // PandaSpigot end
++
+     public Entity getEntity(UUID uuid) {
+         return (Entity) this.entitiesByUUID.get(uuid);
+     }


### PR DESCRIPTION
Sends a time sync packet immediately after waking up. This should make players wake up to daylight as long as they aren't lagging too much.

Fixes the issue that it takes up to `timeUpdateFrequency` ticks in pandaspigot.yml + network delay for players to have their time refreshed after waking up, so they'd wake up to it still being night that suddenly turns into a day.
As a sidenote I don't really understand what was the reasoning for the `timeUpdateFrequency` to be configurable in the first place, its not as if sending a small packet to all players once per second had any performance effect.

With the update frequency default of 5 seconds this is most helpful as up to 5 seconds + network delay players spend still in night after waking up without the patch. But even with vanilla value of 1 second, this still helps as now you should be waking up to daylight from bed without seeing any night at all as long as you don't have a lot of network delay.
