### PR TITLE
Include dependencies in API jar

### DIFF
--- a/patches/api/0003-Setup-Gradle-project.patch
+++ b/patches/api/0003-Setup-Gradle-project.patch
@@ -6,12 +6,13 @@ Subject: [PATCH] Setup Gradle project
 
 diff --git a/build.gradle.kts b/build.gradle.kts
 new file mode 100644
-index 0000000000000000000000000000000000000000..260e26967f8b8b0d617345eea3ed9a728d1e43d8
+index 0000000000000000000000000000000000000000..17836f8338282c00ebf4675fb57131478d675a64
 --- /dev/null
 +++ b/build.gradle.kts
-@@ -0,0 +1,128 @@
+@@ -0,0 +1,139 @@
 +plugins {
 +    id("pandaspigot.conventions")
++    id("com.gradleup.shadow") version "9.4.1"
 +    `maven-publish`
 +}
 +
@@ -53,7 +54,17 @@ index 0000000000000000000000000000000000000000..260e26967f8b8b0d617345eea3ed9a72
 +        }
 +    }
 +
++    shadowJar {
++        archiveClassifier.set("")
++    }
++
++    named("build") {
++        dependsOn(named("shadowJar"))
++    }
++
 +    jar {
++        archiveClassifier.set("original")
++
 +        from(generateApiVersioningFile.map { it.outputs.files.singleFile }) {
 +            into("META-INF/maven/${project.group}/${project.name.lowercase()}")
 +        }

--- a/patches/api/0003-Setup-Gradle-project.patch
+++ b/patches/api/0003-Setup-Gradle-project.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Setup Gradle project
 
 diff --git a/build.gradle.kts b/build.gradle.kts
 new file mode 100644
-index 0000000000000000000000000000000000000000..17836f8338282c00ebf4675fb57131478d675a64
+index 0000000000000000000000000000000000000000..4476529604e907b77b75e0fa513bba149d868803
 --- /dev/null
 +++ b/build.gradle.kts
-@@ -0,0 +1,139 @@
+@@ -0,0 +1,137 @@
 +plugins {
 +    id("pandaspigot.conventions")
 +    id("com.gradleup.shadow") version "9.4.1"
@@ -54,17 +54,15 @@ index 0000000000000000000000000000000000000000..17836f8338282c00ebf4675fb5713147
 +        }
 +    }
 +
-+    shadowJar {
-+        archiveClassifier.set("")
-+    }
++	shadowJar {
++		archiveClassifier.set("shaded")
++	}
 +
 +    named("build") {
 +        dependsOn(named("shadowJar"))
 +    }
 +
 +    jar {
-+        archiveClassifier.set("original")
-+
 +        from(generateApiVersioningFile.map { it.outputs.files.singleFile }) {
 +            into("META-INF/maven/${project.group}/${project.name.lowercase()}")
 +        }

--- a/patches/api/0022-Add-SLF4J-implementation.patch
+++ b/patches/api/0022-Add-SLF4J-implementation.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add SLF4J implementation
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 260e26967f8b8b0d617345eea3ed9a728d1e43d8..d98d86623ef945ae233fa37b7017c83311eb1cd1 100644
+index 17836f8338282c00ebf4675fb57131478d675a64..0bcff7067e0df01cd613c4ed16a7c004d632e10d 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -21,6 +21,7 @@ dependencies {
+@@ -22,6 +22,7 @@ dependencies {
      // bundled with Minecraft, should be kept in sync
      api("com.google.guava:guava:17.0")
      api("com.google.code.gson:gson:2.2.4")
@@ -16,7 +16,7 @@ index 260e26967f8b8b0d617345eea3ed9a728d1e43d8..d98d86623ef945ae233fa37b7017c833
  
      // testing
      testImplementation("junit:junit:4.12")
-@@ -64,6 +65,7 @@ tasks {
+@@ -75,6 +76,7 @@ tasks {
                  "https://javadoc.io/doc/org.yaml/snakeyaml/1.15/",
                  "https://javadoc.io/doc/com.google.code.gson/gson/2.2.4/",
                  "https://repo.hpfxd.com/javadoc/releases/net/md-5/bungeecord-chat/1.8-SNAPSHOT/raw/",

--- a/patches/api/0022-Add-SLF4J-implementation.patch
+++ b/patches/api/0022-Add-SLF4J-implementation.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add SLF4J implementation
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 17836f8338282c00ebf4675fb57131478d675a64..0bcff7067e0df01cd613c4ed16a7c004d632e10d 100644
+index 4476529604e907b77b75e0fa513bba149d868803..0742b5c85e6e6d40917ec532d47c7aa953c79a30 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -22,6 +22,7 @@ dependencies {
@@ -16,7 +16,7 @@ index 17836f8338282c00ebf4675fb57131478d675a64..0bcff7067e0df01cd613c4ed16a7c004
  
      // testing
      testImplementation("junit:junit:4.12")
-@@ -75,6 +76,7 @@ tasks {
+@@ -73,6 +74,7 @@ tasks {
                  "https://javadoc.io/doc/org.yaml/snakeyaml/1.15/",
                  "https://javadoc.io/doc/com.google.code.gson/gson/2.2.4/",
                  "https://repo.hpfxd.com/javadoc/releases/net/md-5/bungeecord-chat/1.8-SNAPSHOT/raw/",

--- a/patches/api/0027-Adventure-API.patch
+++ b/patches/api/0027-Adventure-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Adventure API
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 0bcff7067e0df01cd613c4ed16a7c004d632e10d..9d17385129cda1307f1845185087ec3aee7461ad 100644
+index 0bcff7067e0df01cd613c4ed16a7c004d632e10d..9646fbb40ffbfab25690ba0a0e58a4bbba1c5b1a 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -9,6 +9,8 @@ java {
@@ -17,7 +17,7 @@ index 0bcff7067e0df01cd613c4ed16a7c004d632e10d..9d17385129cda1307f1845185087ec3a
  dependencies {
      api("commons-lang:commons-lang:2.6")
      api("org.avaje:ebean:2.8.1")
-@@ -17,6 +19,13 @@ dependencies {
+@@ -17,6 +19,14 @@ dependencies {
      }
      api("org.yaml:snakeyaml:1.15")
      api("net.md-5:bungeecord-chat:1.8-SNAPSHOT")
@@ -27,11 +27,12 @@ index 0bcff7067e0df01cd613c4ed16a7c004d632e10d..9d17385129cda1307f1845185087ec3a
 +    api("net.kyori:adventure-text-serializer-legacy:$adventureVersion")
 +    api("net.kyori:adventure-text-serializer-gson:$adventureVersion")
 +    api("net.kyori:adventure-text-serializer-plain:$adventureVersion")
++    api("org.jetbrains:annotations:26.0.2")
 +    // PandaSpigot end
      compileOnlyApi("net.sf.trove4j:trove4j:3.0.3") // provided by server
  
      // bundled with Minecraft, should be kept in sync
-@@ -77,6 +86,13 @@ tasks {
+@@ -77,6 +87,13 @@ tasks {
                  "https://javadoc.io/doc/com.google.code.gson/gson/2.2.4/",
                  "https://repo.hpfxd.com/javadoc/releases/net/md-5/bungeecord-chat/1.8-SNAPSHOT/raw/",
                  "https://javadoc.io/doc/org.slf4j/slf4j-api/1.7.35/", // PandaSpigot - Add SLF4J Logger

--- a/patches/api/0027-Adventure-API.patch
+++ b/patches/api/0027-Adventure-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Adventure API
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index d98d86623ef945ae233fa37b7017c83311eb1cd1..6e727d855493daeae6a2d8e649fad95ea25db1ce 100644
+index 0bcff7067e0df01cd613c4ed16a7c004d632e10d..9d17385129cda1307f1845185087ec3aee7461ad 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -8,6 +8,8 @@ java {
+@@ -9,6 +9,8 @@ java {
      withJavadocJar()
  }
  
@@ -17,7 +17,7 @@ index d98d86623ef945ae233fa37b7017c83311eb1cd1..6e727d855493daeae6a2d8e649fad95e
  dependencies {
      api("commons-lang:commons-lang:2.6")
      api("org.avaje:ebean:2.8.1")
-@@ -16,6 +18,13 @@ dependencies {
+@@ -17,6 +19,13 @@ dependencies {
      }
      api("org.yaml:snakeyaml:1.15")
      api("net.md-5:bungeecord-chat:1.8-SNAPSHOT")
@@ -31,7 +31,7 @@ index d98d86623ef945ae233fa37b7017c83311eb1cd1..6e727d855493daeae6a2d8e649fad95e
      compileOnlyApi("net.sf.trove4j:trove4j:3.0.3") // provided by server
  
      // bundled with Minecraft, should be kept in sync
-@@ -66,6 +75,13 @@ tasks {
+@@ -77,6 +86,13 @@ tasks {
                  "https://javadoc.io/doc/com.google.code.gson/gson/2.2.4/",
                  "https://repo.hpfxd.com/javadoc/releases/net/md-5/bungeecord-chat/1.8-SNAPSHOT/raw/",
                  "https://javadoc.io/doc/org.slf4j/slf4j-api/1.7.35/", // PandaSpigot - Add SLF4J Logger

--- a/patches/api/0027-Adventure-API.patch
+++ b/patches/api/0027-Adventure-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Adventure API
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 0bcff7067e0df01cd613c4ed16a7c004d632e10d..9646fbb40ffbfab25690ba0a0e58a4bbba1c5b1a 100644
+index 0bcff7067e0df01cd613c4ed16a7c004d632e10d..9d17385129cda1307f1845185087ec3aee7461ad 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -9,6 +9,8 @@ java {
@@ -17,7 +17,7 @@ index 0bcff7067e0df01cd613c4ed16a7c004d632e10d..9646fbb40ffbfab25690ba0a0e58a4bb
  dependencies {
      api("commons-lang:commons-lang:2.6")
      api("org.avaje:ebean:2.8.1")
-@@ -17,6 +19,14 @@ dependencies {
+@@ -17,6 +19,13 @@ dependencies {
      }
      api("org.yaml:snakeyaml:1.15")
      api("net.md-5:bungeecord-chat:1.8-SNAPSHOT")
@@ -27,12 +27,11 @@ index 0bcff7067e0df01cd613c4ed16a7c004d632e10d..9646fbb40ffbfab25690ba0a0e58a4bb
 +    api("net.kyori:adventure-text-serializer-legacy:$adventureVersion")
 +    api("net.kyori:adventure-text-serializer-gson:$adventureVersion")
 +    api("net.kyori:adventure-text-serializer-plain:$adventureVersion")
-+    api("org.jetbrains:annotations:26.0.2")
 +    // PandaSpigot end
      compileOnlyApi("net.sf.trove4j:trove4j:3.0.3") // provided by server
  
      // bundled with Minecraft, should be kept in sync
-@@ -77,6 +87,13 @@ tasks {
+@@ -77,6 +86,13 @@ tasks {
                  "https://javadoc.io/doc/com.google.code.gson/gson/2.2.4/",
                  "https://repo.hpfxd.com/javadoc/releases/net/md-5/bungeecord-chat/1.8-SNAPSHOT/raw/",
                  "https://javadoc.io/doc/org.slf4j/slf4j-api/1.7.35/", // PandaSpigot - Add SLF4J Logger

--- a/patches/api/0027-Adventure-API.patch
+++ b/patches/api/0027-Adventure-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Adventure API
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 0bcff7067e0df01cd613c4ed16a7c004d632e10d..9d17385129cda1307f1845185087ec3aee7461ad 100644
+index 0742b5c85e6e6d40917ec532d47c7aa953c79a30..acd689b740a1c63f6b59825bfe2833665eaa4477 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -9,6 +9,8 @@ java {
@@ -31,7 +31,7 @@ index 0bcff7067e0df01cd613c4ed16a7c004d632e10d..9d17385129cda1307f1845185087ec3a
      compileOnlyApi("net.sf.trove4j:trove4j:3.0.3") // provided by server
  
      // bundled with Minecraft, should be kept in sync
-@@ -77,6 +86,13 @@ tasks {
+@@ -75,6 +84,13 @@ tasks {
                  "https://javadoc.io/doc/com.google.code.gson/gson/2.2.4/",
                  "https://repo.hpfxd.com/javadoc/releases/net/md-5/bungeecord-chat/1.8-SNAPSHOT/raw/",
                  "https://javadoc.io/doc/org.slf4j/slf4j-api/1.7.35/", // PandaSpigot - Add SLF4J Logger


### PR DESCRIPTION
This PR adds the shadow plugin to the api build.gradle.kts, which adds the everything in the dependencies to the output jar. The original jar is renamed to (name)-original.jar.

This also adds org.jetbrains:annotations:26.0.2 to the Adventure patch. This library is required by adventure-api, but isn't automatically added for some reason.

This should fix #425, but I'll need confirmation from @anzz1