### PR TITLE
panda script improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ Normal commands:
 | `setup` | Remap, decompile, and patch Minecraft. Can be run from anywhere. |
 | `p`, `patch` | Apply all patches to the project without building it. Can be run from anywhere. |
 | `j`, `jar` | Build the project, `paperclip.jar` will be output. Can be run from anywhere. |
-| `c`, `clean` | Removes all generated files, `PandaSpigot-API`, `PandaSpigot-Server`, and `work`. |
+| `c`, `clean` | Removes build files under `PandaSpigot-API`, `PandaSpigot-Server`. |
+| `dc`, `distclean` | Removes all generated files, `PandaSpigot-API`, `PandaSpigot-Server`, and work. |
 | `con`, `continue` | Shortcut command for running `git am --continue` or `git rebase --continue`. |
 
 Commands that require `. ./panda install` first:

--- a/panda
+++ b/panda
@@ -83,10 +83,15 @@ case "$1" in
         cd "$basedir/PandaSpigot-Server"
     ;;
     "c" | "clean")
+        rm -rf PandaSpigot-API/build
+        rm -rf PandaSpigot-Server/build
+        echo "Cleaned PandaSpigot build files"
+    ;;
+    "dc" | "distclean")
         rm -rf PandaSpigot-API
         rm -rf PandaSpigot-Server
         rm -rf base
-        echo "Cleaned build files"
+        echo "Cleaned ALL generated files"
     ;;
     "con" | "continue")
         if [ -d ".git/rebase-apply" ]; then
@@ -163,7 +168,8 @@ case "$1" in
         echo "  * setup               | Remap, decompile, and patch Minecraft. Can be run from anywhere."
         echo "  * p, patch            | Apply all patches to the project without building it. Can be run from anywhere."
         echo "  * j, jar              | Apply all patches and build the project, paperclip.jar will be output. Can be run from anywhere."
-        echo "  * c, clean            | Removes all generated files, PandaSpigot-API, PandaSpigot-Server, and work."
+        echo "  * c, clean            | Removes build files under PandaSpigot-API, PandaSpigot-Server."
+        echo "  * dc, distclean       | Removes all generated files, PandaSpigot-API, PandaSpigot-Server, and work."
         echo "  * con, continue       | Shortcut command for running git am --continue, or git rebase --continue."
         echo ""
         echo " These commands require the install command before use:"

--- a/panda
+++ b/panda
@@ -87,11 +87,12 @@ case "$1" in
         rm -rf PandaSpigot-Server/build
         echo "Cleaned PandaSpigot build files"
     ;;
-    "dc" | "distclean")
+    "dc" | "distclean" | "reset")
         rm -rf PandaSpigot-API
         rm -rf PandaSpigot-Server
         rm -rf base
-        echo "Cleaned ALL generated files"
+        rm -rf work
+        echo "Cleaned ALL generated, build and work files"
     ;;
     "con" | "continue")
         if [ -d ".git/rebase-apply" ]; then
@@ -169,7 +170,7 @@ case "$1" in
         echo "  * p, patch            | Apply all patches to the project without building it. Can be run from anywhere."
         echo "  * j, jar              | Apply all patches and build the project, paperclip.jar will be output. Can be run from anywhere."
         echo "  * c, clean            | Removes build files under PandaSpigot-API, PandaSpigot-Server."
-        echo "  * dc, distclean       | Removes all generated files, PandaSpigot-API, PandaSpigot-Server, and work."
+        echo "  * dc, distclean       | Removes all generated files, PandaSpigot-API, PandaSpigot-Server, base, and work."
         echo "  * con, continue       | Shortcut command for running git am --continue, or git rebase --continue."
         echo ""
         echo " These commands require the install command before use:"


### PR DESCRIPTION
- old `clean` is now `distclean`, as canonically "clean" should only remove build files and not your current working state. Not fun when you don't RTFM and assume "clean" does what it usually does but nukes your work instead.

- `clean` is now a new command that just removes the build files under PandaSpigot-API/build and PandaSpigot-Server/build, leaving your working state intact, as you'd expect.
