### PR TITLE
Fix title times in Adventure

### DIFF
--- a/patches/server/0111-Adventure-API.patch
+++ b/patches/server/0111-Adventure-API.patch
@@ -649,7 +649,7 @@ index 43adfccd72c0629f5b93c735119fa4f84074d12b..5f39a8dff50d59cea70d6050f4e17101
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 49477a0f4d237db75d869ed91dc5088f4b4385fe..09ec7de882201fe89323f8ff67e7e76128f8ae1e 100644
+index 49477a0f4d237db75d869ed91dc5088f4b4385fe..3ab7bb133e31a82313c491d62635c8713e5d5968 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -194,6 +194,25 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -678,7 +678,7 @@ index 49477a0f4d237db75d869ed91dc5088f4b4385fe..09ec7de882201fe89323f8ff67e7e761
  
      @Override
      public void setTitleTimes(int fadeInTicks, int stayTicks, int fadeOutTicks) {
-@@ -258,6 +277,26 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -258,6 +277,30 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  
@@ -692,7 +692,11 @@ index 49477a0f4d237db75d869ed91dc5088f4b4385fe..09ec7de882201fe89323f8ff67e7e761
 +            getHandle().playerConnection.sendPacket(new PacketPlayOutTitle(action, ichatbasecomponent));
 +        } else if (part.equals(net.kyori.adventure.title.TitlePart.TIMES)) {
 +            net.kyori.adventure.title.Title.Times times = (net.kyori.adventure.title.Title.Times) value;
-+            getHandle().playerConnection.sendPacket(new PacketPlayOutTitle(times.fadeIn().getNano(), times.stay().getNano(), times.fadeOut().getNano()));
++            getHandle().playerConnection.sendPacket(new PacketPlayOutTitle(
++                (int) (times.fadeIn().toMillis() / 50),
++                (int) (times.stay().toMillis() / 50),
++                (int) (times.fadeOut().toMillis() / 50)
++            ));
 +        }
 +    }
 +
@@ -705,7 +709,7 @@ index 49477a0f4d237db75d869ed91dc5088f4b4385fe..09ec7de882201fe89323f8ff67e7e761
      @Override
      public String getDisplayName() {
          return getHandle().displayName;
-@@ -266,6 +305,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -266,6 +309,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public void setDisplayName(final String name) {
          getHandle().displayName = name == null ? getName() : name;
@@ -713,7 +717,7 @@ index 49477a0f4d237db75d869ed91dc5088f4b4385fe..09ec7de882201fe89323f8ff67e7e761
      }
  
      @Override
-@@ -286,6 +326,34 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -286,6 +330,34 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  
@@ -748,7 +752,7 @@ index 49477a0f4d237db75d869ed91dc5088f4b4385fe..09ec7de882201fe89323f8ff67e7e761
      @Override
      public boolean equals(Object obj) {
          if (!(obj instanceof OfflinePlayer)) {
-@@ -314,6 +382,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -314,6 +386,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          getHandle().playerConnection.disconnect(message == null ? "" : message);
      }
  


### PR DESCRIPTION
This PR fixes title times in the built-in Adventure API. 1.8 expects the times in ticks, however we had this in nanoseconds instead.